### PR TITLE
Update fun.admin.php: declare $userId in function cambio_estado

### DIFF
--- a/common/include/fun.admin.php
+++ b/common/include/fun.admin.php
@@ -803,6 +803,8 @@ GLOBAL $DBCFG;
 $tema_id=secure_data($tema_id,"int");
 
 $estado_id=secure_data($estado_id,"int");
+	
+$userId=$_SESSION[$_SESSION["CFGURL"]]["ssuser_id"];
 
 switch($estado_id)
 	{


### PR DESCRIPTION
There was a bug related to changing a term status (rejected, accepted, candidate).
Impact: SQL error in uid_final column => Impossible to change the status of the term.
Root cause: the $userId variable was not defined in the function cambio_estado.
I corrected this bug. 