### PR TITLE
Change warning in BulkReplace (search notes)

### DIFF
--- a/common/include/fun.html_forms.php
+++ b/common/include/fun.html_forms.php
@@ -2162,7 +2162,7 @@ function HTMLbulkReplaceResultsNotes($params){
 
 		$rows.='<form class="form-inline" role="form" name="confirmBulkReplace" action="admin.php?doAdmin=bulkReplace" method="post">';
 		$rows.='  <fieldset id="bulkReplaceDiv">';
-		$rows.= '<p class="alert alert-warning" role="alert">'.MSG__warningDeleteTerm2row.'</p>';
+		$rows.= '<p class="alert alert-warning" role="alert">'.LABEL_warningBulkEditor.'</p>';
 		$rows.='<div class="table-responsive"> ';
 		$rows.='<table class="table table-striped table-bordered table-condensed table-hover"">';
 		$rows.='<thead><tr>';


### PR DESCRIPTION
Previous warning (MSG__warningDeleteTerm2row) was not relevant (Bulk replace operations on notes does not delete notes nor relations). 
Before:
![searchnote-en](https://cloud.githubusercontent.com/assets/2683883/24830272/b094370e-1cac-11e7-91e3-46ccea27b14a.png)

After:
![after-en](https://cloud.githubusercontent.com/assets/2683883/24830287/0191f02e-1cad-11e7-9404-2fd19518b843.png)

