### PR TITLE
2 correction: in function SQLfixDobleChar4Notes

### DIFF
--- a/common/include/fun.admin.php
+++ b/common/include/fun.admin.php
@@ -3786,9 +3786,9 @@ function SQLbulkGlossNote($from,$to,$where,$notesType,$term_id,$replaceType=1){
 
 //replace double char in notes
 function SQLfixDobleChar4Notes($notesType,$char,$charX2){
-
-	return SQL("update","$DBCFG[DBprefix]notas set nota=replace(nota, $charX2, $char)
-						where nota like BINARY $charX2
+        GLOBAL $DBCFG;
+	return SQL("update","$DBCFG[DBprefix]notas set nota=replace(nota, '$charX2', '$char')
+						where nota like BINARY '$charX2'
 						and tipo_nota='$notesType'");
 
 }


### PR DESCRIPTION
In relation to Admin / Auto-glossary config. screen.

1st correction: add simple quote in the SQL statement around $char and
$charX2 variables.
![sqlerror](https://cloud.githubusercontent.com/assets/2683883/25040382/2cb48bd8-2133-11e7-839b-b2bd3a35e732.png)


2nd correction: declare $DBCFG to handle the prefix of the table
'notas'.
![sqlerror2](https://cloud.githubusercontent.com/assets/2683883/25040406/59fe025e-2133-11e7-8a24-9decf88823ea.png)
