### PR TITLE
Fix typo for portuguese language name

### DIFF
--- a/common/include/config.tematres.php
+++ b/common/include/config.tematres.php
@@ -134,7 +134,7 @@ $idiomas_disponibles = array(
      "nl"  => array("Vlaams","nl-$CFG[_CHAR_ENCODE].inc.php", "nl","nl-$CFG[_CHAR_ENCODE]"),
      "cn"  => array("汉语, 漢語","cn-$CFG[_CHAR_ENCODE].inc.php", "cn","cn-$CFG[_CHAR_ENCODE]"),
      "pl"  => array("polski","pl-$CFG[_CHAR_ENCODE].inc.php", "pl","pl-$CFG[_CHAR_ENCODE]"),
-     "pt"  => array("portugüés","pt-$CFG[_CHAR_ENCODE].inc.php", "pt","ptbr-$CFG[_CHAR_ENCODE]"),
+     "pt"  => array("português","pt-$CFG[_CHAR_ENCODE].inc.php", "pt","ptbr-$CFG[_CHAR_ENCODE]"),
      "ru"  => array("Pусский","ru-$CFG[_CHAR_ENCODE].inc.php", "ru","ru-$CFG[_CHAR_ENCODE]")
     );
 

--- a/common/lang/en-utf-8.inc.php
+++ b/common/lang/en-utf-8.inc.php
@@ -241,7 +241,7 @@ $idiomas_disponibles = array(
      "it"  => array("italiano","", "it"),
      "nl"  => array("nederlands","", "nl"),
      "pl"  => array("polski","", "pl"),
-     "pt"  => array("portugüés","", "pt"),
+     "pt"  => array("português","", "pt"),
      "ru"  => array("Pусский","", "ru")
     );
 /* Install messages */

--- a/common/lang/es-utf-8.inc.php
+++ b/common/lang/es-utf-8.inc.php
@@ -241,7 +241,7 @@ $idiomas_disponibles = array(
      "it"  => array("italiano","", "it"),
      "nl"  => array("nederlands","", "nl"),
      "pl"  => array("polski","", "pl"),
-     "pt"  => array("portugüés","", "pt"),
+     "pt"  => array("português","", "pt"),
      "ru"  => array("Pусский","", "ru")
     );
 /* Install messages */

--- a/vocab/install.php
+++ b/vocab/install.php
@@ -634,7 +634,7 @@ function HTMLformInstall($lang_install)
 							<option value="en">english</option>
 							<option value="es">español</option>
 							<option value="fr">fran&ccedil;ais</option>
-							<option value="pt">portug&uuml;&eacute;s</option>				    </select>
+							<option value="pt">portugu&ecirc;s</option>				    </select>
 				  </div>
 				</div>
 


### PR DESCRIPTION
Fix typo for portuguese language name

Proper name is: `português`
  