### PR TITLE
Translations update

### DIFF
--- a/common/lang/ca-utf-8.inc.php
+++ b/common/lang/ca-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Maribel Cuadrado
-# 2014-03-06 jsau arreglant i completant catala
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
+#
 ###############################################################################################################
 #
 define("LANG","ca");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Terme relacionat");
 define("TE_termino","Terme específic");
 define("TG_termino","Terme genèric");
-define("UP_termino","Usat per");
+define("UP_termino","Usat per"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USEU");
+define("USE_termino","USEU"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Llista sistemàtica");
 define("MENU_ListaAbc","Llista alfabètica");
 define("MENU_Sobre","Quant a...");
@@ -28,10 +29,10 @@ define("MENU_DatosTesauro","Dades del vocabulari");
 define("MENU_AgregarT","Afegir Terme");
 define("MENU_EditT","Editar Terme");
 define("MENU_BorrarT","eliminar Terme");
-define("MENU_AgregarTG","subordinar a terme genèric"); # era 'subordinar a terme'
-define("MENU_AgregarTE","terme específic"); # era 'terme subordinat'
+define("MENU_AgregarTG","subordinar a terme genèric");
+define("MENU_AgregarTE","terme específic");
 define("MENU_AgregarTR","terme relacionat");
-define("MENU_AgregarUP","terme equivalent");
+define("MENU_AgregarUP","terme equivalent");  /* Non-descriptor */
 define("MENU_MisDatos","Les meves dades");
 define("MENU_Caducar","Caducar");
 define("MENU_Habilitar","Habilitar");
@@ -44,14 +45,13 @@ define("LABEL_editT","Modificar terme ");
 define("LABEL_EditorTermino","Editor de terme");
 define("LABEL_Termino","Terme");
 define("LABEL_NotaAlcance","Nota d'abast");
+define("LABEL_EliminarTE","Eliminar terme");
 define("LABEL_AgregarT","Alta de terme");
-define("LABEL_AgregarTG","Subordinar %s a terme genèric"); # era ...  terme superior
-define("LABEL_AgregarTE","Alta d'un terme específic de "); # era ...terme subordinat
+define("LABEL_AgregarTG","Subordinar %s a terme genèric");
+define("LABEL_AgregarTE","Alta d'un terme específic de ");
 define("LABEL_AgregarUP","Alta d'un terme equivalent de ");
 define("LABEL_AgregarTR","Alta d'un terme relacionat amb ");
-define("LABEL_EliminarTE","Eliminar terme");
 define("LABEL_Detalle","detalls");
-define("LABEL_EditarNota","editar nota");
 define("LABEL_Autor","Autor");
 define("LABEL_URI","URI");
 define("LABEL_Version","Generat per");
@@ -70,18 +70,18 @@ define("LABEL_Cambiar","Guardar canvis");
 define("LABEL_Anterior","anterior");
 define("LABEL_AdminUser","Administració d'usuaris");
 define("LABEL_DatosUser","Dades de l'usuari");
-define("LABEL_Acciones","Accions completades"); # era realitzades
+define("LABEL_Acciones","Accions completades");
 define("LABEL_verEsquema","veure esquema");
 define("LABEL_actualizar","Actualitzar");
-define("LABEL_terminosLibres","Termes lliures");
+define("LABEL_terminosLibres","Termes lliures"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Cerca");
 define("LABEL_borraRelacion","eliminar relació");
 define("MSG_ResultBusca","terme/s trobats a la cerca");
 define("MSG_ResultLetra","Lletra");
-define("MSG_ResultCambios","Els canvis s'han fet amb èxit."); # era realitzat
+define("MSG_ResultCambios","Els canvis s'han fet amb èxit.");
 define("MSG_noUser","Usuari no registrat");
-define("FORM_JS_check","Si us plau reviseu les dades de "); # canvi vos
-define("FORM_JS_confirm","Segur que voleu eliminar el terme o la relació?"); # canvi vos
+define("FORM_JS_check","Si us plau reviseu les dades de ");
+define("FORM_JS_confirm","Segur que voleu eliminar el terme o la relació?");
 define("FORM_JS_pass","_clau");
 define("FORM_JS_confirmPass","_repetir_clau");
 define("FORM_LABEL_termino","_terme");
@@ -120,14 +120,15 @@ define("LABEL_verDetalle","veure detalls de ");
 define("LABEL_verTerminosLetra","veure termes que comencen amb ");
 define("LABEL_NB","Nota bibliogràfica");
 define("LABEL_NH","Nota històrica");
-define("LABEL_NA","Nota d'abast"); /* version 0.9.1 */
-define("LABEL_NP","Nota privada");    /* version 0.9.1 */
+define("LABEL_NA","Nota d'abast");   /* version 0.9.1 */
+define("LABEL_NP","Nota privada"); /* version 0.9.1 */
 define("LABEL_EditorNota","Editor de notes");
 define("LABEL_EditorNotaTermino","Notes del terme ");
 define("LABEL_tipoNota","tipus de nota");
 define("FORM_LABEL_tipoNota","tipus_nota");
 define("LABEL_nota","nota");
 define("FORM_LABEL_nota","_nota");
+define("LABEL_EditarNota","editar nota");
 define("LABEL_EliminarNota","Eliminar nota");
 define("LABEL_OptimizarTablas","Optimitzar taules");
 define("LABEL_TotalZthesLine","exportar en Zthes");
@@ -167,7 +168,7 @@ $MONTHS=array("01"=>"Gen",
 define("LABEL_SI","SÍ");
 define("LABEL_NO","NO");
 define("FORM_LABEL_jeraquico","polijerarquia");
-define("LABEL_jeraquico","polijeràrquic");
+define("LABEL_jeraquico","polijeràrquic"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","terme lliure");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Cercar %s a: ");
@@ -183,24 +184,22 @@ define("LABEL_tipo_vocabulario","tipus");
 define("LABEL_termino_equivalente","equival");
 define("LABEL_termino_parcial_equivalente","equival parcialment");
 define("LABEL_termino_no_equivalente","no equival");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota de catalogació");
 define("LABEL_resultados_suplementarios","resultats suplementaris");
 define("LABEL_resultados_relacionados","resultats relacionats");
 /* v 9.7 */
 define("LABEL_export","exportar");
 define("FORM_LABEL_format_export","triar format");
-define("LABEL_siteMap","SiteMap");
-define("LABEL_TotalTopicMap","exportar en TopicMap");
 /* v 1.0 */
 define("LABEL_fecha_creacion","creat");
-define("NB_acronimo","NB");
-define("NH_acronimo","NH");
-define("NA_acronimo","NA");
-define("NP_acronimo","NP");
-define("NC_acronimo","NC");
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NA"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","terme candidat");
 define("LABEL_Aceptado","terme acceptat");
 define("LABEL_Rechazado","terme refusat");
@@ -211,6 +210,7 @@ define("LABEL_Aceptados","termes acceptats");
 define("LABEL_Rechazados","termes refusats");
 define("LABEL_User_NoHabilitado","no habilitat");
 define("LABEL_User_Habilitado","habilitat");
+
 define("LABEL_CandidatearTermino","Passar a estat candidat");
 define("LABEL_AceptarTermino","Acceptar terme");
 define("LABEL_RechazarTermino","Refusar terme");
@@ -239,15 +239,15 @@ define("PARAM_DBName","Database name") ;
 define("PARAM_DBLogin","Database User") ;
 define("PARAM_DBPass","Database Password") ;
 define("PARAM_DBprefix","Prefix tables") ;
-$install_message[101] = "Instal·lació de TemaTres" ;
-$install_message[201] = "No es troba l'arxiu de configuració de la base de dades (%s)." ;
-$install_message[202] = "Arxiu de configuració de la base de dades trobat." ;
-$install_message[203] = "No es pot connectar amb el servidor  <em>%s</em> fent servir l'usuari <em>%s</em>. Si us plau reviseu les dades de l'arxiu de configuració de la base de dades (%s)" ;
-$install_message[204] = "Connexió amb el servidor <em>%s</em> completada" ;
-$install_message[205] = "No es pot  connectar amb la base de dades <em>%s</em> a <em>%s</em>. Si us plau reviseu les dades de l'arxiu de configuració de la base de dades (%s)." ;
-$install_message[206] = "Connexió amb la base de dades <em>%s</em> en <em>%s</em> verificada." ;
-$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = "Indicació sobre el grau de seguretat de la clau.";
+$install_message[101] = 'Instal·lació de TemaTres' ;
+$install_message[201] = 'No es troba l\'arxiu de configuració de la base de dades (%s).';
+$install_message[202] = 'Arxiu de configuració de la base de dades trobat.';
+$install_message[203] = 'No es pot connectar amb el servidor  <em>%s</em> fent servir l\'usuari <em>%s</em>. Si us plau reviseu les dades de l\'arxiu de configuració de la base de dades (%s)';
+$install_message[204] = 'Connexió amb el servidor <em>%s</em> completada';
+$install_message[205] = 'No es pot  connectar amb la base de dades <em>%s</em> a <em>%s</em>. Si us plau reviseu les dades de l\'arxiu de configuració de la base de dades (%s).';
+$install_message[206] = 'Connexió amb la base de dades <em>%s</em> en <em>%s</em> verificada.' ;
+$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. Por favor, compruebe su configuración de archivo para la conexión de base de datos (%s) o <a href="index.php">Comience a utilizar su vocabulario</a>' ;
+$install_message[305] = 'Indicació sobre el grau de seguretat de la clau.' ;
 $install_message[306] = 'Instal·lació completada, <a href="index.php">Ja podeu començar a fer el vocabulari</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -266,7 +266,7 @@ define('LABEL_BusquedaAvanzada',"cerca avançada");
 define('LABEL_Todos',"tots");
 define('LABEL_QueBuscar',"Què cercar?");
 define("LABEL_import","Importar") ;
-define("IMPORT_form_legend","Importar un arxiu de text tabulat") ;
+define("IMPORT_form_legend","Importar un arxiu de text") ;
 define("IMPORT_form_label","Arxiu") ;
 define("IMPORT_file_already_exists","Un arxiu txt ja existeix al servidor") ;
 define("IMPORT_file_not_exists","No hi ha arxius encara") ;
@@ -274,7 +274,7 @@ define("IMPORT_do_it","Podeu iniciar la importació") ;
 define("IMPORT_working","procés d’importació en marxa") ;
 define("IMPORT_finish","importació finalitzada") ;
 define("LABEL_reIndice","Recrear índexs de termes") ;
-define("LABEL_dbMantenimiento","Manteniment de la base de dades") ;
+define("LABEL_dbMantenimiento","Manteniment de la base de dades");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -292,12 +292,12 @@ define('LABEL_notFound',"terme no trobat");
 define('LABEL_termUpdated',"terme actualitzat");
 define('LABEL_ShowTargetTermforUpdate',"actualitzar");
 define('LABEL_relbetweenVocabularies',"relacions entre vocabularis");
-define('LABEL_update1_1x1_2',"Update Tematres (1.1 -> 1.3)");
+define('LABEL_update1_1x1_2',"Update (1.1 -> 1.3)");
 define('LABEL_update1x1_2',"Update Tematres (1.0x -> 1.3)");
 define('LABEL_TargetTerm',"terme extern (mapeig terminològic)");
 define('LABEL_TargetTerms',"termes externs (mapeig terminològic)");
-define('LABEL_seleccionar',"triar");
-define('LABEL_poliBT',"més d'un terme genèric");
+define('LABEL_seleccionar','triar');
+define('LABEL_poliBT','més d\'un terme genèric');
 define('LABEL_FORM_simpleReport','Informes');
 define('LABEL_FORM_advancedReport','Informes avançats');
 define('LABEL_FORM_nullValue','Tant fa');
@@ -325,12 +325,12 @@ define('MSG_noTermsNoBT','No hi ha termes sense relacions jerárquiques');
 define('LABEL_termsXcantWords','Termes segons quantitat de paraules');
 define('LABEL__USE_CODE','permetre codi identificador únic per terme');
 define('LABEL__SHOW_CODE','publicar codi identificador únic per terme');
-define('LABEL_CFG_MAX_TREE_DEEP',"Màxim nivell de profunditat a l'arbre de temes per a la visualització");
-define('LABEL_CFG_VIEW_STATUS',"publicar detalls de l'estat dels termes");
+define('LABEL_CFG_MAX_TREE_DEEP','Màxim nivell de profunditat a l\'arbre de temes per a la visualització');
+define('LABEL_CFG_VIEW_STATUS','publicar detalls de l\'estat dels termes');
 define('LABEL_CFG_SIMPLE_WEB_SERVICE','habilitar web services');
 define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','quantitat de termes per a visualització de llistats segons estats');
 define('LABEL_CFG_MIN_SEARCH_SIZE','mínim de caràcters per a operacions de cerca');
-define('LABEL__SHOW_TREE',"publicar navegació jeràrquica a la pàgina d'inici");
+define('LABEL__SHOW_TREE','publicar navegació jeràrquica a la pàgina d\'inici');
 define('LABEL__PUBLISH_SKOS','permetre consultes SKOS-core a través de serveis web; això podria extreure tot el vocabulari.');
 define('LABEL_update1_3x1_4',"Actualitzar Tematres (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","triar format");
@@ -357,7 +357,7 @@ define("LABEL_URItypeDelete","eliminar tipus d'enllaç");
 define('LABEL_URItype',"tipus d'enllaç");
 define('LABEL_URItypeCode',"alias del tipus d'enllaç");
 define('LABEL_URItypeLabel',"llegenda del tipus d'enllaç");
-define('FORM_JS_confirmDeleteURIdefinition',"Segur que voleu eliminar aquest tipus d'enllaç?");
+define('FORM_JS_confirmDeleteURIdefinition','Segur que voleu eliminar aquest tipus d\'enllaç?');
 define('LABEL_URI2term','recurs web');
 define('LABEL_URI2termURL','Adreça del recurs web');
 define('LABEL_update1_4x1_5','Actualitzar (1.4 -> 1.5)');
@@ -373,29 +373,29 @@ define('LABEL_PageNum','pàgina de resultats número ');
 define('LABEL_selectMapMethod','Trieu mètode de mapeig terminològic');
 define('LABEL_string2search','expressió de cerca');
 define('LABEL_reverseMappign','mapeig invers');
-define('LABEL_warningMassiverem',"Esteu a punt d'eliminar dades massivament. Aquesta acció serà IRREVERSIBLE!");
+define('LABEL_warningMassiverem','Esteu a punt d\'eliminar dades massivament. Aquesta acció serà IRREVERSIBLE!');
 define('LABEL_target_terms','termes mapejats des de vocabularis externs');
 define('LABEL_URI2terms','recursos web');
 define('MENU_massiverem','Esborrat massiu de dades');
 define('LABEL_more','més');
 define('LABEL_less','menys');
-define('LABEL_lastChangeDate',"data d'última modificació");
+define('LABEL_lastChangeDate','data d\'última modificació');
 define('LABEL_update1_5x1_6','Actualitzar (1.5 -> 1.6)');
 define('LABEL_login','accedir');
 define('LABEL_user_recovery_password','Obtenir una nova contrasenya');
 define('LABEL_user_recovery_password1','Sisplau, entreu el vostre correu electrònic. Rebreu un enllaç per a crear la contrasenya.');
-define('LABEL_mail_recoveryTitle',"Recuperar clau d'accés");
+define('LABEL_mail_recoveryTitle','Recuperar clau d\'accés');
 define('LABEL_mail_recovery_pass1','Algú ha demanat una nova contrasenya per al compte:');
-define('LABEL_mail_recovery_pass2',"Nom d'usuari: %s2");
-define('LABEL_mail_recovery_pass3',"Si és un error, no feu cas d'aquest missatge.");
-define('LABEL_mail_recovery_pass4',"Per a canviar la contrasenya, visiteu aquest enllaç:");
+define('LABEL_mail_recovery_pass2','Nom d\'usuari: %s2');
+define('LABEL_mail_recovery_pass3','Si és un error, no feu cas d\'aquest missatge.');
+define('LABEL_mail_recovery_pass4','Per a canviar la contrasenya, visiteu aquest enllaç:');
 define('LABEL_mail_passTitle','Nova clau ');
 define('LABEL_mail_pass1','Nova clau per a ');
 define('LABEL_mail_pass2','Clau: ');
 define('LABEL_mail_pass3','Podeu modificar-la.');
-define('MSG_check_mail_link',"Reviseu el correu electrònic per a obtenir l'enllaç de confirmació.");
+define('MSG_check_mail_link','Reviseu el correu electrònic per a obtenir l\'enllaç de confirmació.');
 define('MSG_check_mail','Sisplau, reviseu el correu electrònic.');
-define('MSG_no_mail',"No s'ha pogut enviar el correu.");
+define('MSG_no_mail','No s\'ha pogut enviar el correu.');
 define('LABEL_user_lost_password','Heu perdut la contrasenya?');
 ## v1.7
 define('LABEL_includeMetaTerm','Incloure meta-termes');
@@ -410,19 +410,19 @@ define('LABEL_nonPreferedTerms','termes no preferits');
 define('LABEL_update1_6x1_7','Actualitzar (1.6 -> 2.2)');
 define('LABEL_include_data','incloure');
 define('LABEL_updateEndpoint','actualitzar punt de consulta SPARQL');
-define('MSG__updateEndpoint',"A continuació s'actualizaran les dades exposades al punt de consulta SPARQL. Aquesta operació pot trigar uns quants minuts.");
-define('MSG__updatedEndpoint',"El punt de consulta SPARQL s'ha actualitzat.");
-define('MSG__dateUpdatedEndpoint',"Data d'última actualització del punt de consulta SPARQL");
+define('MSG__updateEndpoint','A continuació s\'actualizaran les dades exposades al punt de consulta SPARQL. Aquesta operació pot trigar uns quants minuts.');
+define('MSG__updatedEndpoint','El punt de consulta SPARQL s\'ha actualitzat.');
+define('MSG__dateUpdatedEndpoint','Data d\'última actualització del punt de consulta SPARQL');
 define('LABEL__ENABLE_SPARQL','Cal actualitzar el punt de consulta: Menú Administració -> Manteniment de la base de dades -> Actualitzar punt de consulta SPARQL.');
 define('MSG__disable_endpoint','El punt de consulta SPARQL està deshabilitat.');
-define('MSG__need2setup_endpoint',"El punt de consulta SPARQL ha de ser actualizat. Contacteu amb l'administrador");
+define('MSG__need2setup_endpoint','El punt de consulta SPARQL ha de ser actualizat. Contacteu amb l\'administrador');
 define('LABEL_SPARQLEndpoint','punt de consulta SPARQL');
 define('LABEL_AgregarRTexist','associar un terme associat existent amb ');
 define('MENU_selectExistTerm','triar terme existent');
 define("TT_terminos","Termes superiors");
 ## v1.72
-define('MSG__warningDeleteTerm',"El terme <i>%s</i> será <strong>ELIMINAT</strong>.");
-define('MSG__warningDeleteTerm2row',"S'eliminaran <strong>totes</strong> les seves notes i relacions terminològiques. Aquesta acció serà IRREVERSIBLE!");
+define('MSG__warningDeleteTerm','El terme <i>%s</i> será <strong>ELIMINAT</strong>.');
+define('MSG__warningDeleteTerm2row','S\'eliminaran <strong>totes</strong> les seves notes i relacions terminològiques. Aquesta acció serà IRREVERSIBLE!');
 ## v1.8
 define('LABEL__getForRecomendation','buscar recomendaciones');
 define('LABEL__getForRecomendationFor','buscar recomendaciones para ');
@@ -450,7 +450,7 @@ define('LABEL_defaultEQmap','Utilice "eq" para indicar relación de equivalencia
 define("MSG_repass_error","las claves no coinciden");
 define("MSG_lengh_error","mínimo de %d caracteres");
 define("MSG_errorPostData","Ha ocurrido un error, por favor revise los datos correspondiente al campo ");
-define('LABEL_preferedTerms','términos preferidos');
+define('LABEL_preferedTerms','términos preferidos');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','términos SIN notas');
 define('MSG_FORM_NULLnotesTermReport','términos que no tienen notas de tipo');
 define('LABELnoNotes','términos sin ninguna nota');
@@ -501,6 +501,14 @@ define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término s
 define('LABEL_opt_show_rando_term','presentar términos con nota:');
 define('MSG_helpNoteEditor','Puede vincular términos utilizando corchetes dobles. Ej: Sólo el [[amor]] salvará el mundo');
 define('LABEL_GLOSS_NOTES','Seleccionar tipo de nota para glosar términos marcados con corchetes dobles: [[glosario]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referencias');
@@ -513,4 +521,11 @@ define('LABEL_termsNoEQ','sin correspondencias');
 define('LABEL_close','cerrar');
 define('LABEL_allTerms','todos los términos');
 define('LABEL_allNotes','todas las notas');
-define('LABEL_allRelations','todas las relaciones entre términos');?>
+define('LABEL_allRelations','todas las relaciones entre términos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
+?>

--- a/common/lang/cn-utf-8.inc.php
+++ b/common/lang/cn-utf-8.inc.php
@@ -1,14 +1,23 @@
-﻿<?php define("LANG","cn");
-define("TR_acronimo","参 RT");
-define("TE_acronimo","分 NT");
-define("TG_acronimo","属 BT");
-define("UP_acronimo","代 UF");
+<?php
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
+#   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
+#
+###############################################################################################################
+#
+define("LANG","cn");
+define("TR_acronimo","参 RT"); /* Related Term */
+define("TE_acronimo","分 NT"); /* Narrower term > Specific term */
+define("TG_acronimo","属 BT"); /* Broader term > Generic term */
+define("UP_acronimo","代 UF"); /* Used for > instead */
 define("TR_termino","相关词");
 define("TE_termino","狭义词");
 define("TG_termino","广义词");
-define("UP_termino","代用");
+define("UP_termino","代用"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","用");
+define("USE_termino","用"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","等级列表");
 define("MENU_ListaAbc","字顺列表");
 define("MENU_Sobre","关于...");
@@ -23,7 +32,7 @@ define("MENU_BorrarT","删除词条");
 define("MENU_AgregarTG","建立从属");
 define("MENU_AgregarTE","下位词");
 define("MENU_AgregarTR","相关词");
-define("MENU_AgregarUP","非选词");
+define("MENU_AgregarUP","非选词");  /* Non-descriptor */
 define("MENU_MisDatos","我的帐户");
 define("MENU_Caducar","停用");
 define("MENU_Habilitar","可用e");
@@ -64,13 +73,13 @@ define("LABEL_DatosUser","用户数据");
 define("LABEL_Acciones","任务");
 define("LABEL_verEsquema","显示模式");
 define("LABEL_actualizar","更新");
-define("LABEL_terminosLibres","自由词");
+define("LABEL_terminosLibres","自由词"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","查找");
 define("LABEL_borraRelacion","删除关系");
 define("MSG_ResultBusca","检索式命中词条数 ");
 define("MSG_ResultLetra","字母");
 define("MSG_ResultCambios","更新成功");
-define("MSG_noUser","<p>不是一个注册用户</p>");
+define("MSG_noUser","不是一个注册用户");
 define("FORM_JS_check","请核对数据");
 define("FORM_JS_confirm","删除这个关系吗？");
 define("FORM_JS_pass","_密码 ");
@@ -159,7 +168,7 @@ $MONTHS=array("01"=>"一月",
 define("LABEL_SI","是");
 define("LABEL_NO","否");
 define("FORM_LABEL_jeraquico","多层等级");
-define("LABEL_jeraquico","多层等级");
+define("LABEL_jeraquico","多层等级"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","自由词");
 /* v 9.5 */
 define("LABEL_URL_busqueda","在%s中检索");
@@ -175,40 +184,72 @@ define("LABEL_tipo_vocabulario","类型");
 define("LABEL_termino_equivalente","等价");
 define("LABEL_termino_parcial_equivalente","部分等价");
 define("LABEL_termino_no_equivalente","不等价");
-define("EQ_acronimo","等价");
-define("EQP_acronimo","部分等价");
-define("NEQ_acronimo","不等价");
+define("EQ_acronimo","等价"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","部分等价"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","不等价"); /*  Non-equivalence */
 define("LABEL_NC","编目员注释");
 define("LABEL_resultados_suplementarios","补充检索结果");
 define("LABEL_resultados_relacionados","相关检索结果");
 /* v 9.7 */
 define("LABEL_export","导出");
 define("FORM_LABEL_format_export","选择XML Schema");
+/* v 1.0 */
+define("LABEL_fecha_creacion","created");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
+define("LABEL_Candidato","candidate term");
+define("LABEL_Aceptado","accepted term");
+define("LABEL_Rechazado","rejected term");
+define("LABEL_Ultimos_aceptados","last accepted terms");
+define("MSG_ERROR_ESTADO","ilegal status");
+define("LABEL_Candidatos","candidate terms");
+define("LABEL_Aceptados","accepted terms");
+define("LABEL_Rechazados","rejected terms");
+define("LABEL_User_NoHabilitado","停用");
+define("LABEL_User_Habilitado","enable");
+
+define("LABEL_CandidatearTermino","candidate term");
+define("LABEL_AceptarTermino","accept term");
+define("LABEL_RechazarTermino","reject term");
+/* v 1.01 */
+define("LABEL_TERMINO_SUGERIDO","did you mean:");
+/* v 1.02 */
+define("LABEL_esSuperUsuario","is admin");
+define("LABEL_Cancelar","cancel");
+define("LABEL_Guardar","save");
 /* v 1.033 */
 define("MENU_AgregarTEexist","Subordinate An Existing Term");
 define("MENU_AgregarUPexist","Associate An Existing Non-Preferred Term");
 define("LABEL_existAgregarUP","Add UF term to %s");
-define("LABEL_existAgregarTE","Add narrow Term to %s ");
+define("LABEL_existAgregarTE","Add narrower term to %s ");
 define("MSG_minCharSerarch","The search expression <i>%s</i> has only <strong>%s </strong> characters. Must be greater than <strong>%s</strong> characters");
 /* v 1.04 */
 define("LABEL_terminoExistente","exist term");
 define("HELP_variosTerminos","To add multiple terms at once please put <strong>one a term per line</strong>.");
-/* v 1.05 */
-$idiomas_disponibles = array(
-     "ca"  => array("català", "", "ca"),
-     "cn"  => array("中文","", "cn"),
-     "de"  => array("deutsch","", "de"),
-     "en"  => array("english", "", "en"),
-     "es"  => array("español", "", "es"),
-     "eu"  => array("euskera", "", "eu"),
-     "fr"  => array("français","", "fr"),
-     "gl"  => array("galego","", "gl"),
-     "it"  => array("italiano","", "it"),
-     "nl"  => array("nederlands","", "nl"),
-     "pl"  => array("polski","", "pl"),
-     "pt"  => array("portugüés","", "pt"),
-     "ru"  => array("Pусский","", "ru")
-    );
+/* Install messages */
+define("FORM","Form") ;
+define("ERROR","Error") ;
+define("LABEL_bienvenida","Welcome to TemaTres Vocabulary Server") ;
+// COMMON SQL
+define("PARAM_SERVER","Server address") ;
+define("PARAM_DBName","Database name") ;
+define("PARAM_DBLogin","Database User") ;
+define("PARAM_DBPass","Database Password") ;
+define("PARAM_DBprefix","Prefix tables") ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
+$install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+/* end Install messages */
 /* v 1.1 */
 define('MSG_ERROR_CODE',"invalid code");
 define('LABEL_CODE',"code");
@@ -223,17 +264,17 @@ define('LABEL_ProfundidadTermino',"is located in deep level");
 define('LABEL_esNoPreferido',"non preferred term");
 define('LABEL_BusquedaAvanzada',"advanced search");
 define('LABEL_Todos',"all");
-define('LABEL_QueBuscar',"what search?");
+define('LABEL_QueBuscar',"what to search?");
 define("LABEL_import","import") ;
 define("IMPORT_form_legend","import thesaurus from file") ;
 define("IMPORT_form_label","file") ;
 define("IMPORT_file_already_exists","a txt file is already present on the server") ;
 define("IMPORT_file_not_exists","no import txt file yet") ;
 define("IMPORT_do_it","You can start the import") ;
-define("IMPORT_working","import task are working") ;
+define("IMPORT_working","import task is working") ;
 define("IMPORT_finish","import task finished") ;
 define("LABEL_reIndice","recreate indexes") ;
-define("LABEL_dbMantenimiento","maintenance database");
+define("LABEL_dbMantenimiento","database maintenance");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -246,19 +287,19 @@ define('LABEL_tvocab_uri_service',"URL for the web services reference");
 define('LABEL_targetTermsforUpdate',"terms with pending update");
 define('LABEL_ShowTargetTermsforUpdate',"check terms update");
 define('LABEL_enable',"enable");
-define('LABEL_disable',"disable");
+define('LABEL_disable',"停用");
 define('LABEL_notFound',"term not found");
 define('LABEL_termUpdated',"term updated");
 define('LABEL_ShowTargetTermforUpdate',"update");
 define('LABEL_relbetweenVocabularies',"relations between vocabularies");
-define('LABEL_update1_1x1_2',"Update Tematres (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"Update Tematres (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"terminological mapping)");
+define('LABEL_update1_1x1_2',"Update (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Update (1.0x -> 1.3)");
+define('LABEL_TargetTerm',"terminological mapping");
 define('LABEL_TargetTerms',"terms (terminological mapping)");
 define('LABEL_seleccionar','select');
 define('LABEL_poliBT','more than one broader term');
-define('LABEL_FORM_simpleReport','reports');
-define('LABEL_FORM_advancedReport','advances reports');
+define('LABEL_FORM_simpleReport','Reports');
+define('LABEL_FORM_advancedReport','advanced reports');
 define('LABEL_FORM_nullValue','no matters');
 define('LABEL_FORM_haveNoteType','have note type');
 define('LABEL_haveEQ','have equivalences');
@@ -290,8 +331,8 @@ define('LABEL_CFG_SIMPLE_WEB_SERVICE','enable web services');
 define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','Number of terms display by status view');
 define('LABEL_CFG_MIN_SEARCH_SIZE','Minimum characters for search operations');
 define('LABEL__SHOW_TREE','publish hierarchical view in home');
-define('LABEL__PUBLISH_SKOS','enable Skos-core format in web services. This could to expose entire your vocabulary.');
-define('LABEL_update1_3x1_4',"Update Tematres (1.3x -> 1.4)");
+define('LABEL__PUBLISH_SKOS','enable SKOS-Core format in web services. This will expose your entire vocabulary.');
+define('LABEL_update1_3x1_4',"Update (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","choose format");
 define("LABEL_importTab","tabulated text");
 define("LABEL_importTag","tagged text");
@@ -308,7 +349,7 @@ define("LABEL_relationDelete","delete relation sub-type");
 define('LABEL_relationSubType',"relation type");
 define('LABEL_relationSubTypeCode',"relation sub-type alias");
 define('LABEL_relationSubTypeLabel',"relation sub-type label");
-define('LABEL_optative',"opcional");
+define('LABEL_optative',"optional");
 define('FORM_JS_confirmDeleteTypeRelation','delete this relation sub-type?');
 define("LABEL_URItypeEditor","link type editor");
 define("LABEL_URIEditor","manage links associated to the term");
@@ -340,7 +381,7 @@ define('LABEL_more','more');
 define('LABEL_less','less');
 define('LABEL_lastChangeDate','last change date');
 define('LABEL_update1_5x1_6','Update (1.5 -> 1.6)');
-define('LABEL_login','acceder');
+define('LABEL_login','login');
 define('LABEL_user_recovery_password','Get new password');
 define('LABEL_user_recovery_password1','Please enter your username or email address. You will receive a link to create a new password via email.');
 define('LABEL_mail_recoveryTitle','Password Reset');
@@ -355,36 +396,36 @@ define('LABEL_mail_pass3','You can change it.');
 define('MSG_check_mail_link','Check your e-mail for the confirmation link.');
 define('MSG_check_mail','Please check your e-mail.');
 define('MSG_no_mail','The e-mail could not be sent.');
-define('LABEL_user_lost_password',' Lost your password?');
+define('LABEL_user_lost_password','Lost your password?');
 ## v1.7
 define('LABEL_includeMetaTerm','Include meta-terms');
 define('NOTE_isMetaTerm','Is a meta-term.');
-define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be use in indexing process. Is a term to describe others terms. Ej: Guide terms, Facets, Categories, etc.');
+define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be used in the indexing process. It is a term to describe others terms. For example: Guide terms, Facets, Categories, etc.');
 define('LABEL_turnOffMetaTerm','Is not a meta-term');
 define('LABEL_turnOnMetaTerm','Is a meta-term');
 define('LABEL_meta_term','meta-term');
 define('LABEL_meta_terms','meta-terms');
 define('LABEL_relatedTerms','related terms');
-define('LABEL_nonPreferedTerms','non preferred terms');
-define('LABEL_update1_6x1_7','Update TemaTres (1.6 -> 2.2)');
+define('LABEL_nonPreferedTerms','非选用词');
+define('LABEL_update1_6x1_7','Update (1.6 -> 2.2)');
 define('LABEL_include_data','include');
 define('LABEL_updateEndpoint','update SPARQL endpoint');
 define('MSG__updateEndpoint','The data will be updated to be exposed in SPARQL endpoint. This operation may take several minutes.');
 define('MSG__updatedEndpoint','The SPARQL endpoint is updated.');
 define('MSG__dateUpdatedEndpoint','Last updated of SPARQL endpoint');
 define('LABEL__ENABLE_SPARQL','You must update the SPARQL endpoint: Menu -> Administration -> Database maintance -> Update SPARQL endpoint.');
-define('MSG__disable_endpoint','The SPARQL endpoint is disable.');
-define('MSG__need2setup_endpoint','The SPARQL endpoint need to be updated. Please contact to the administrator.');
+define('MSG__disable_endpoint','The SPARQL endpoint is disabled.');
+define('MSG__need2setup_endpoint','The SPARQL endpoint needs to be updated. Please contact the administrator.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','Select terms to link as related term with');
+define('LABEL_AgregarRTexist','Select terms to link as related term with ');
 define('MENU_selectExistTerm','select existing term');
 define("TT_terminos","top terms");
 ## v1.72
 define('MSG__warningDeleteTerm','The term <i>%s</i> will be <strong>DELETED</strong>.');
-define('MSG__warningDeleteTerm2row','Will be deleted <strong>all</strong> his notes and relations. These action are irreversible!');
+define('MSG__warningDeleteTerm2row','Will delete <strong>all</strong> the term\'s notes and relations. These actions are irreversible!');
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -393,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -406,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -419,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -440,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -449,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
 define('LABEL_TTTerms','top terms');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -473,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/de-utf-8.inc.php
+++ b/common/lang/de-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
 #   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 0.97
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","de");
-define("TR_acronimo","Verwandter Begriff: ");
-define("TE_acronimo","Unterbegriff: ");
-define("TG_acronimo","Oberbegriff: ");
-define("UP_acronimo","Synonymbegriff: ");
+define("TR_acronimo","Verwandter Begriff: "); /* Related Term */
+define("TE_acronimo","Unterbegriff: "); /* Narrower term > Specific term */
+define("TG_acronimo","Oberbegriff: "); /* Broader term > Generic term */
+define("UP_acronimo","Synonymbegriff: "); /* Used for > instead */
 define("TR_termino","Verwandter Begriff: ");
 define("TE_termino","Unterbegriff: ");
 define("TG_termino","Oberbegriff: ");
-define("UP_termino","Synonymbegriff: ");
+define("UP_termino","Synonymbegriff: "); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","siehe");
+define("USE_termino","BS"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Hierarchisch");
 define("MENU_ListaAbc","Alphabetisch");
 define("MENU_Sobre","Info & Statistik");
@@ -31,7 +32,7 @@ define("MENU_BorrarT","Begriff löschen");
 define("MENU_AgregarTG","Mit existierenden Oberbegriffen");
 define("MENU_AgregarTE","Mit Unterbegriffen");
 define("MENU_AgregarTR","Mit sonstigen verwandten Begriffen");
-define("MENU_AgregarUP","Mit Synonymen");
+define("MENU_AgregarUP","Mit Synonymen");  /* Non-descriptor */
 define("MENU_MisDatos","Mein Konto");
 define("MENU_Caducar","inaktiv");
 define("MENU_Habilitar","aktiv");
@@ -66,13 +67,13 @@ define("LABEL_BuscaTermino","Suchbegriff");
 define("LABEL_Buscar","Suche");
 define("LABEL_Enviar","Start");
 define("LABEL_Cambiar","Aktualisieren");
-define("LABEL_Anterior","<b>Zurück</b>");
+define("LABEL_Anterior","Zurück");
 define("LABEL_AdminUser","Benutzerverwaltung");
 define("LABEL_DatosUser","Benutzerangaben");
 define("LABEL_Acciones","Aufgaben");
 define("LABEL_verEsquema","Eintrag konvertieren nach ");
 define("LABEL_actualizar","Aktualisieren");
-define("LABEL_terminosLibres","Begriffe ohne Relationen");
+define("LABEL_terminosLibres","Begriffe ohne Relationen"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Suchergebnis");
 define("LABEL_borraRelacion","Relation löschen");
 define("MSG_ResultBusca","Begriff(e) gefunden für: ");
@@ -111,15 +112,15 @@ define("FORM_LABEL_FechaAno","year");
 define("FORM_LABEL_Keywords","keywords");
 define("FORM_LABEL_TipoLenguaje","language_type");
 define("FORM_LABEL_Cobertura","scope");
-define("FORM_LABEL_Terminos","terms");
-define("FORM_LABEL_RelTerminos","relations between terms");
+define("FORM_LABEL_Terminos","Angelegte Begriffe");
+define("FORM_LABEL_RelTerminos","Angelegte Begriffsrelationen");
 define("FORM_LABEL_TerminosUP","Non preferred terms");
 define("FORM_LABEL_Guardar","Speichern");
 define("LABEL_verDetalle","Details für: ");
 define("LABEL_verTerminosLetra","Begriffe mit Anfangsbuchstabe ");
 define("LABEL_NB","Quelle");
 define("LABEL_NH","Entstehungsgeschichte");
-define("LABEL_NA","Definition");   /* version 0.9.1 */
+define("LABEL_NA","Scope note");   /* version 0.9.1 */
 define("LABEL_NP","Allgemein"); /* version 0.9.1 */
 define("LABEL_EditorNota","Kommentar bearbeiten ");
 define("LABEL_EditorNotaTermino","Kommentarfeld für den Begriff ");
@@ -138,7 +139,7 @@ define("LABEL_subrayado","unterstrichen");
 define("LABEL_textarea","Anmerkungen");
 define("MSGL_relacionIlegal","Relation nicht zulässig!");
 /* v 9.3 */
-define("LABEL_fecha_modificacion","<br>Aktualisiert");
+define("LABEL_fecha_modificacion","aktualisiert");
 define("LABEL_TotalUsuarios","Benutzer gesamt");
 define("LABEL_TotalTerminos","Begriffe gesamt");
 define("LABEL_ordenar","Sortieren nach");
@@ -167,12 +168,12 @@ $MONTHS=array("01"=>"Januar",
 define("LABEL_SI","YES");
 define("LABEL_NO","NO");
 define("FORM_LABEL_jeraquico","Polihierarchical");
-define("LABEL_jeraquico","Polyhierarchische Strukturen aktivieren");
+define("LABEL_jeraquico","Polyhierarchische Strukturen aktivieren"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","free term");
 /* v 9.5 */
-define("LABEL_URL_busqueda","Search %s in:");
+define("LABEL_URL_busqueda","Search %s in: ");
 /* v 9.6 */
-define("LABEL_relacion_vocabulario","Begriff aus einem anderen Thesaurus finden und verknüpfen mit ");
+define("LABEL_relacion_vocabulario","Begriff aus einem anderen Thesaurus finden und verknüpfen mit");
 define("FORM_LABEL_relacion_vocabulario","equivalence");
 define("FORM_LABEL_nombre_vocabulario","Interner Thesaurus");
 define("LABEL_vocabulario_referencia","Interner Thesaurus");
@@ -183,9 +184,9 @@ define("LABEL_tipo_vocabulario","Typ");
 define("LABEL_termino_equivalente","Volläquivalenz");
 define("LABEL_termino_parcial_equivalente","Teiläquivalenz");
 define("LABEL_termino_no_equivalente","Nichtäquivalenz");
-define("EQ_acronimo","Volläquivanlenz");
-define("EQP_acronimo","Teiläqivalenz");
-define("NEQ_acronimo","Nichtäquivalenz");
+define("EQ_acronimo","Volläquivanlenz"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","Teiläqivalenz"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","Nichtäquivalenz"); /*  Non-equivalence */
 define("LABEL_NC","Sonstiges");
 define("LABEL_resultados_suplementarios","Weitere Treffer");
 define("LABEL_resultados_relacionados","Verwandte Treffer");
@@ -194,11 +195,11 @@ define("LABEL_export","Datenexport");
 define("FORM_LABEL_format_export","Zielformat wählen");
 /* v 1.0 */
 define("LABEL_fecha_creacion","created");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","D"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
 define("LABEL_Candidato","Ist Begriffskandidat?");
 define("LABEL_Aceptado","Freigegeben");
 define("LABEL_Rechazado","Abgelehnt");
@@ -209,7 +210,7 @@ define("LABEL_Aceptados","Freigegebene Begriffe");
 define("LABEL_Rechazados","Abgelehnte Begriffe");
 define("LABEL_User_NoHabilitado","deaktiviert");
 define("LABEL_User_Habilitado","aktiviert");
-// define("LABEL_CandidatearTermino","Candidatear término");
+
 define("LABEL_CandidatearTermino","Begriffskandidat");
 define("LABEL_AceptarTermino","Begriff freigeben");
 define("LABEL_RechazarTermino","Begriff ablehnen");
@@ -228,7 +229,6 @@ define("MSG_minCharSerarch","Ihr Suchbegriff <i>%s</i> ist <strong>%s </strong> 
 /* v 1.04 */
 define("LABEL_terminoExistente","existierender Begriff");
 define("HELP_variosTerminos","HINWEIS: Um mehrere Begriffe anzulegen, geben Sie <strong>einen Begriff pro Zeile</strong> ein.");
-
 /* Install messages */
 define("FORM","Form") ;
 define("ERROR","Error") ;
@@ -239,20 +239,20 @@ define("PARAM_DBName","Database name") ;
 define("PARAM_DBLogin","Database User") ;
 define("PARAM_DBPass","Database Password") ;
 define("PARAM_DBprefix","Prefix tables") ;
-$install_message[101] = "TemaTres Setup" ;
-$install_message[201] = "Can not found the file configuration for the database connection (%s)." ;
-$install_message[202] = "File configuration for the database connection found." ;
-$install_message[203] = "Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s)." ;
-$install_message[204] = "Connect to Server <em>%s</em> success" ;
-$install_message[205] = "Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s)." ;
-$install_message[206] = "Connect to database <em>%s</em> in server <em>%s</em> success." ;
-$install_message[301] = 'Woppsss... There is already an Tematres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
-$install_message[305] = " Checking Security password." ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
 $install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
 /* end Install messages */
 /* v 1.1 */
 define('MSG_ERROR_CODE',"invalid code");
-define('LABEL_CODE',"Code");
+define('LABEL_CODE',"code");
 define('LABEL_Ver',"Abfragen");
 define('LABEL_OpcionesTermino',"term");
 define('LABEL_CambiarEstado',"Status ändern");
@@ -271,10 +271,10 @@ define("IMPORT_form_label","Datei") ;
 define("IMPORT_file_already_exists","a txt file is already present on the server") ;
 define("IMPORT_file_not_exists","no import txt file yet") ;
 define("IMPORT_do_it","You can start the import") ;
-define("IMPORT_working","import task are working") ;
+define("IMPORT_working","import task is working") ;
 define("IMPORT_finish","import task finished") ;
 define("LABEL_reIndice","Reindizierung") ;
-define("LABEL_dbMantenimiento","Datenbank");
+define("LABEL_dbMantenimiento","Datenbank");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -400,32 +400,32 @@ define('LABEL_user_lost_password',' Passwort vergessen? - ACHTUNG: FUNKTIONIERT 
 ## v1.7
 define('LABEL_includeMetaTerm','Include meta-terms');
 define('NOTE_isMetaTerm','Is a meta-term.');
-define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be use in indexing process. Is a term to describe others terms. Ej: Guide terms, Facets, Categories, etc.');
+define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be used in the indexing process. It is a term to describe others terms. For example: Guide terms, Facets, Categories, etc.');
 define('LABEL_turnOffMetaTerm','Is not a meta-term');
 define('LABEL_turnOnMetaTerm','Is a meta-term');
 define('LABEL_meta_term','meta-term');
 define('LABEL_meta_terms','meta-terms');
 define('LABEL_relatedTerms','related terms');
-define('LABEL_nonPreferedTerms','non preferred terms');
-define('LABEL_update1_6x1_7','Update TemaTres (1.6 -> 2.2)');
+define('LABEL_nonPreferedTerms','Angelegte Synonymbegriffe');
+define('LABEL_update1_6x1_7','Update (1.6 -> 2.2)');
 define('LABEL_include_data','include');
 define('LABEL_updateEndpoint','update SPARQL endpoint');
 define('MSG__updateEndpoint','The data will be updated to be exposed in SPARQL endpoint. This operation may take several minutes.');
 define('MSG__updatedEndpoint','The SPARQL endpoint is updated.');
 define('MSG__dateUpdatedEndpoint','Last updated of SPARQL endpoint');
 define('LABEL__ENABLE_SPARQL','You must update the SPARQL endpoint: Menu -> Administration -> Database maintance -> Update SPARQL endpoint.');
-define('MSG__disable_endpoint','The SPARQL endpoint is disable.');
-define('MSG__need2setup_endpoint','The SPARQL endpoint need to be updated. Please contact to the administrator.');
+define('MSG__disable_endpoint','The SPARQL endpoint is disabled.');
+define('MSG__need2setup_endpoint','The SPARQL endpoint needs to be updated. Please contact the administrator.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','Select terms to link as related term with');
+define('LABEL_AgregarRTexist','Select terms to link as related term with ');
 define('MENU_selectExistTerm','select existing term');
 define("TT_terminos","top terms");
 ## v1.72
 define('MSG__warningDeleteTerm','The term <i>%s</i> will be <strong>DELETED</strong>.');
-define('MSG__warningDeleteTerm2row','Will be deleted <strong>all</strong> his notes and relations. These action are irreversible!');
+define('MSG__warningDeleteTerm2row','Will delete <strong>all</strong> the term\'s notes and relations. These actions are irreversible!');
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -434,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -447,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -460,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -481,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -490,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
 define('LABEL_TTTerms','top terms');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -514,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/en-utf-8.inc.php
+++ b/common/lang/en-utf-8.inc.php
@@ -224,7 +224,7 @@ define("LABEL_Guardar","save");
 define("MENU_AgregarTEexist","Subordinate An Existing Term");
 define("MENU_AgregarUPexist","Associate An Existing Non-Preferred Term");
 define("LABEL_existAgregarUP","Add UF term to %s");
-define("LABEL_existAgregarTE","Add narrow Term to %s ");
+define("LABEL_existAgregarTE","Add narrower term to %s ");
 define("MSG_minCharSerarch","The search expression <i>%s</i> has only <strong>%s </strong> characters. Must be greater than <strong>%s</strong> characters");
 /* v 1.04 */
 define("LABEL_terminoExistente","exist term");
@@ -264,7 +264,7 @@ define('LABEL_ProfundidadTermino',"is located in deep level");
 define('LABEL_esNoPreferido',"non preferred term");
 define('LABEL_BusquedaAvanzada',"advanced search");
 define('LABEL_Todos',"all");
-define('LABEL_QueBuscar',"what search?");
+define('LABEL_QueBuscar',"what to search?");
 define("LABEL_import","import") ;
 define("IMPORT_form_legend","import thesaurus from file") ;
 define("IMPORT_form_label","file") ;

--- a/common/lang/es-utf-8.inc.php
+++ b/common/lang/es-utf-8.inc.php
@@ -1,21 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   #
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
+#
 ###############################################################################################################
 #
 define("LANG","es");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Término relacionado");
 define("TE_termino","Término específico");
 define("TG_termino","Término general");
-define("UP_termino","Usados por");
+define("UP_termino","Usados por"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USE");
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Lista sistemática");
 define("MENU_ListaAbc","Lista alfabética");
 define("MENU_Sobre","Sobre...");
@@ -30,7 +32,7 @@ define("MENU_BorrarT","eliminar término");
 define("MENU_AgregarTG","subordinar a un término");
 define("MENU_AgregarTE","término subordinado");
 define("MENU_AgregarTR","término relacionado");
-define("MENU_AgregarUP","término equivalente");
+define("MENU_AgregarUP","término equivalente");  /* Non-descriptor */
 define("MENU_MisDatos","Mis datos");
 define("MENU_Caducar","Caducar");
 define("MENU_Habilitar","Habilitar");
@@ -43,14 +45,13 @@ define("LABEL_editT","Modificar término ");
 define("LABEL_EditorTermino","Editor de término");
 define("LABEL_Termino","Término");
 define("LABEL_NotaAlcance","Nota de alcance");
+define("LABEL_EliminarTE","Eliminar término");
 define("LABEL_AgregarT","Alta de término");
-define("LABEL_AgregarTG","Subordinar %s a término superior");
+define("LABEL_AgregarTG","Subordinar %s a término superior ");
 define("LABEL_AgregarTE","Alta de un término subordinado a ");
 define("LABEL_AgregarUP","Alta de un término equivalente para ");
 define("LABEL_AgregarTR","Alta de término relacionado con ");
-define("LABEL_EliminarTE","Eliminar término");
 define("LABEL_Detalle","detalles");
-define("LABEL_EditarNota","editar nota");
 define("LABEL_Autor","Autor");
 define("LABEL_URI","URI");
 define("LABEL_Version","Generado por");
@@ -72,7 +73,7 @@ define("LABEL_DatosUser","Datos del usuario");
 define("LABEL_Acciones","Acciones realizadas");
 define("LABEL_verEsquema","ver esquema");
 define("LABEL_actualizar","Actualizar");
-define("LABEL_terminosLibres","Términos libres");
+define("LABEL_terminosLibres","Términos libres"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Búsqueda");
 define("LABEL_borraRelacion","eliminar relación");
 define("MSG_ResultBusca","término/s encontrados para la búsqueda");
@@ -119,14 +120,15 @@ define("LABEL_verDetalle","ver detalles de ");
 define("LABEL_verTerminosLetra","ver términos iniciados con ");
 define("LABEL_NB","Nota bibliográfica");
 define("LABEL_NH","Nota histórica");
-define("LABEL_NA","Nota de alcance"); /* version 0.9.1 */
-define("LABEL_NP","Nota privada");    /* version 0.9.1 */
-define("LABEL_EditorNota","Editor de notas");
+define("LABEL_NA","Nota de alcance");   /* version 0.9.1 */
+define("LABEL_NP","Nota privada"); /* version 0.9.1 */
+define("LABEL_EditorNota","Editor de notas ");
 define("LABEL_EditorNotaTermino","Notas del término ");
 define("LABEL_tipoNota","tipo de nota");
 define("FORM_LABEL_tipoNota","tipo_nota");
 define("LABEL_nota","nota");
 define("FORM_LABEL_nota","_nota");
+define("LABEL_EditarNota","editar nota");
 define("LABEL_EliminarNota","Eliminar nota");
 define("LABEL_OptimizarTablas","Optimizar tablas");
 define("LABEL_TotalZthesLine","exportar en Zthes");
@@ -166,7 +168,7 @@ $MONTHS=array("01"=>"Ene",
 define("LABEL_SI","SI");
 define("LABEL_NO","NO");
 define("FORM_LABEL_jeraquico","polijerarquia");
-define("LABEL_jeraquico","Polijerarquía");
+define("LABEL_jeraquico","Polijerarquía"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","término libre");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Buscar %s en: ");
@@ -182,24 +184,22 @@ define("LABEL_tipo_vocabulario","tipo");
 define("LABEL_termino_equivalente","equivale");
 define("LABEL_termino_parcial_equivalente","equivale parcialmente");
 define("LABEL_termino_no_equivalente","no equivale");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota de catalogación");
 define("LABEL_resultados_suplementarios","resultados suplementarios");
 define("LABEL_resultados_relacionados","resultados relacionados");
 /* v 9.7 */
 define("LABEL_export","exportar");
 define("FORM_LABEL_format_export","seleccionar formato");
-define("LABEL_siteMap","SiteMap");
-define("LABEL_TotalTopicMap","exportar en TopicMap");
 /* v 1.0 */
 define("LABEL_fecha_creacion","creado");
-define("NB_acronimo","NB");
-define("NH_acronimo","NH");
-define("NA_acronimo","NA");
-define("NP_acronimo","NP");
-define("NC_acronimo","NC");
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NA"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","término candidato");
 define("LABEL_Aceptado","término aceptado");
 define("LABEL_Rechazado","término rechazado");
@@ -210,6 +210,7 @@ define("LABEL_Aceptados","términos aceptados");
 define("LABEL_Rechazados","términos rechazados");
 define("LABEL_User_NoHabilitado","no habilitado");
 define("LABEL_User_Habilitado","habilitado");
+
 define("LABEL_CandidatearTermino","Pasar a estado candidato");
 define("LABEL_AceptarTermino","Aceptar término");
 define("LABEL_RechazarTermino","Rechazar término");
@@ -231,22 +232,22 @@ define("HELP_variosTerminos","Para agregar varios términos a la vez consigne <s
 /* Install messages */
 define("FORM","Form") ;
 define("ERROR","Error") ;
-define("LABEL_bienvenida","Bienvenido a TemaTres...") ;
+define("LABEL_bienvenida","Bienvenido a TemaTres") ;
 // COMMON SQL
 define("PARAM_SERVER","Server address") ;
 define("PARAM_DBName","Database name") ;
 define("PARAM_DBLogin","Database User") ;
 define("PARAM_DBPass","Database Password") ;
 define("PARAM_DBprefix","Prefix tables") ;
-$install_message[101] = "Instalación de TemaTres" ;
-$install_message[201] = "No se encuentra el archivo de configuración de la base de datos (%s)." ;
-$install_message[202] = "Archivo de configuración de la base de datos encontrado." ;
-$install_message[203] = "No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)" ;
-$install_message[204] = "Conexión con el servidor <em>%s</em> exitosa" ;
-$install_message[205] = "No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)." ;
-$install_message[206] = "Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada." ;
-$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = "Indiación acerca del grado de seguridad de la clave." ;
+$install_message[101] = 'Instalación de TemaTres' ;
+$install_message[201] = 'No se encuentra el archivo de configuración de la base de datos (%s).';
+$install_message[202] = 'Archivo de configuración de la base de datos encontrado.';
+$install_message[203] = 'No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s).';
+$install_message[204] = 'Conexión con el servidor <em>%s</em> exitosa ';
+$install_message[205] = 'No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s).';
+$install_message[206] = 'Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada.' ;
+$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. Por favor, compruebe su configuración de archivo para la conexión de base de datos (%s) o <a href="index.php">Comience a utilizar su vocabulario</a>' ;
+$install_message[305] = 'Indiación acerca del grado de seguridad de la clave.' ;
 $install_message[306] = 'Instalación completa, <a href="index.php">comience a utilizar su vocabulario</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -273,7 +274,7 @@ define("IMPORT_do_it","Puede iniciar la importación") ;
 define("IMPORT_working","proceso de importanción en marcha") ;
 define("IMPORT_finish","importación finalizada") ;
 define("LABEL_reIndice","Recrear índices de términos") ;
-define("LABEL_dbMantenimiento","Mantenimiento de la base de datos") ;
+define("LABEL_dbMantenimiento","Mantenimiento de la base de datos");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -285,11 +286,11 @@ define('LABEL_tvocab_tag',"etiqueta de la referencia");
 define('LABEL_tvocab_uri_service',"URL del servicio web de referencia");
 define('LABEL_targetTermsforUpdate',"términos con actualizaciones pendientes");
 define('LABEL_ShowTargetTermsforUpdate',"actualizar términos");
-define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_enable',"habilitado");
 define('LABEL_disable',"deshabilitado");
 define('LABEL_notFound',"término no encontrado");
 define('LABEL_termUpdated',"término actualizado");
+define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_relbetweenVocabularies',"relaciones entre vocabularios");
 define('LABEL_update1_1x1_2',"Actualizar (1.1 -> 1.3)");
 define('LABEL_update1x1_2',"Actualizar (1.0x -> 1.3)");
@@ -414,7 +415,7 @@ define('MSG__updatedEndpoint','El punto de consulta SPARQL se encuentra actualiz
 define('MSG__dateUpdatedEndpoint','Fecha de última actualización del punto de consulta SPARQL');
 define('LABEL__ENABLE_SPARQL','Deberá actualizar el punto de consulta: Menú Administración -> Mantenimiento de la base de datos -> Actualizar punto de consulta SPARQL.');
 define('MSG__disable_endpoint','El punto de consulta SPARQL se encuentra deshabilitado.');
-define('MSG__need2setup_endpoint','El punto de consulta SPARQL se necesita ser actualizado. Contacte al administrador');
+define('MSG__need2setup_endpoint','El punto de consulta SPARQL se necesita ser actualizado. Contacte al administrador.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
 define('LABEL_AgregarRTexist','asociar un término asociado existente con ');
 define('MENU_selectExistTerm','seleccionar término existente');
@@ -449,7 +450,7 @@ define('LABEL_defaultEQmap','Utilice "eq" para indicar relación de equivalencia
 define("MSG_repass_error","las claves no coinciden");
 define("MSG_lengh_error","mínimo de %d caracteres");
 define("MSG_errorPostData","Ha ocurrido un error, por favor revise los datos correspondiente al campo ");
-define('LABEL_preferedTerms','términos preferidos');
+define('LABEL_preferedTerms','términos preferidos');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','términos SIN notas');
 define('MSG_FORM_NULLnotesTermReport','términos que no tienen notas de tipo');
 define('LABELnoNotes','términos sin ninguna nota');
@@ -483,8 +484,6 @@ define('LABEL_ALLOW_DUPLICATED','¿se permiten términos duplicados?');
 define('LABEL_CFG_PUBLISH','¿el vocabulario puede ser consultado por cualquiera?');
 define('LABEL_Replace','reemplazar');
 define('LABEL_Preview','vista previa');
-define('LABEL_Replace','reemplazar');
-define('LABEL_Preview','vista previa');
 #v.2.2
 define('LABEL_selectRelation','seleccionar relación');
 define('LABEL_withSelected','con los seleccionados:');
@@ -503,18 +502,17 @@ define('LABEL_opt_show_rando_term','presentar términos con nota:');
 define('MSG_helpNoteEditor','Puede vincular términos utilizando corchetes dobles. Ej: Sólo el [[amor]] salvará el mundo');
 define('LABEL_GLOSS_NOTES','Seleccionar tipo de nota para glosar términos marcados con corchetes dobles: [[glosario]]');
 define('LABEL_bulkGlossNotes','glosar la nota de tipo');
-define('MSG__autoGlossInfo','Este proceso vincula términos existentes en el vocabulario con sus menciones en notas utilizando la notación Wiki (Ej: <i>Sólo el [[amor]] salvará el mundo</i>). Es una operación de búsqueda y reemplazo de texto <strong>sensible a mayúsculas</strong>.');
-define('MSG__autoGlossDanger','Esta operación modifica datos de manera IRREVERSIBLE. Antes de proceder, realice un respaldo de seguridad');
+define('MSG__autoGlossInfo','Este proceso vincula términos existentes en el vocabulario con sus menciones en notas utilizando la notación Wiki (Ej: Sólo el [[amor]] salvará el mundo). Es una operación de búsqueda y reemplazo de texto <strong>sensible a mayúsculas</strong>.');
+define('MSG__autoGlossDanger','Esta operación modifica datos de manera IRREVERSIBLE. Antes de proceder, realice un respaldo de seguridad.');
 define('LABEL_replaceBinary','Sensible mayúsculas y acentos');
 define('MSG_notesAffected','notas afectadas');
 define('MSG_cantTermsFound','términos encontrados');
-define('MENU_glossConfig','configurar autoglosario');
+define('MENU_glossConfig','configurar autoglosario'); /* Used as menu entry. Keep it short */ 
 define('LABEL_generateAutoGlossary','generación de auto-glosario');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referencias');
 define('LABEL_printData','fecha de impresión');
-
 ##v.3
 define('MENU_bulkTranslate','editor multilingüe');
 define('LABEL_bulkTranslate','editor de traducciones y equivalencias');
@@ -524,4 +522,10 @@ define('LABEL_close','cerrar');
 define('LABEL_allTerms','todos los términos');
 define('LABEL_allNotes','todas las notas');
 define('LABEL_allRelations','todas las relaciones entre términos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/eu-utf-8.inc.php
+++ b/common/lang/eu-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 0.97
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","eu");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Termino erlazionatua");
 define("TE_termino","Berariazko terminoa");
 define("TG_termino","Termino orokorra");
-define("UP_termino","Erabilita");
+define("UP_termino","Erabilita"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USE");
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Azkar sistematikoa");
 define("MENU_ListaAbc","Alfabetikoa lista ezazu");
 define("MENU_Sobre","ren gainetik...");
@@ -31,7 +32,7 @@ define("MENU_BorrarT","Terminoa eliminatzea");
 define("MENU_AgregarTG","Terminoa batera mendean jartzea");
 define("MENU_AgregarTE","Terminoa mendean jarria");
 define("MENU_AgregarTR","Erlazionatua terminoa");
-define("MENU_AgregarUP","Baliokide terminoa");
+define("MENU_AgregarUP","Baliokide terminoa");  /* Non-descriptor */
 define("MENU_MisDatos","Nire datuak");
 define("MENU_Caducar","Epea amaitzea");
 define("MENU_Habilitar","Prestatzea");
@@ -44,14 +45,13 @@ define("LABEL_editT","Terminoa aldatzea ");
 define("LABEL_EditorTermino","TerminoarenEditorea");
 define("LABEL_Termino","Términoa");
 define("LABEL_NotaAlcance","Irismen nabari du");
+define("LABEL_EliminarTE","Terminoa eliminatzea");
 define("LABEL_AgregarT","TerminoarenAltua");
-define("LABEL_AgregarTG","Goiko terminora mendean jartzea");
+define("LABEL_AgregarTG","Goiko terminora mendean jartzea %s ");
 define("LABEL_AgregarTE","Terminoa bat mendean jarriaren altua ");
 define("LABEL_AgregarUP","Baliokide terminoa baten altua ");
 define("LABEL_AgregarTR","Terminoa erlazionatuaren altua ");
-define("LABEL_EliminarTE","Terminoa eliminatzea");
 define("LABEL_Detalle","Detaileak");
-define("LABEL_EditarNota","Nota editatzea");
 define("LABEL_Autor","Egilea");
 define("LABEL_URI","URI");
 define("LABEL_Version","Sortuta");
@@ -73,7 +73,7 @@ define("LABEL_DatosUser","ErabiltzailearenDatuak");
 define("LABEL_Acciones","Ekintza eginak");
 define("LABEL_verEsquema","Eskema ikustea");
 define("LABEL_actualizar","Eguneratzea");
-define("LABEL_terminosLibres","Terminoak askeak");
+define("LABEL_terminosLibres","Terminoak askeak"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Bilaketa");
 define("LABEL_borraRelacion","Zerikusia eliminatzea");
 define("MSG_ResultBusca","BilaketarentzatAurkako terminoak");
@@ -84,7 +84,7 @@ define("FORM_JS_check","Mesedez datuak berrikusi ditzan ");
 define("FORM_JS_confirm","Hau asegurua eliminatzea desiratzen duela edo zerikusia bukatzen dut?");
 define("FORM_JS_pass","_Klabea");
 define("FORM_JS_confirmPass","_Klabea_errepikatzea");
-define("FORM_LABEL_terminoa","_terminoa");
+define("FORM_LABEL_termino","_term");
 define("FORM_LABEL_buscar","_Busqueda-arenAdierazpena");
 define("FORM_LABEL_buscarTermino","_Terminoa_erlazionatua");
 define("FORM_LABEL_nombre","_Izena");
@@ -120,14 +120,15 @@ define("LABEL_verDetalle","Detaileak ikustea ");
 define("LABEL_verTerminosLetra","Terminoak hasiak ikustea ");
 define("LABEL_NB","Bibliografikoa nabari du");
 define("LABEL_NH","Historikoa nabari du");
-define("LABEL_NA","Irismen nabari du"); /* version 0.9.1 */
-define("LABEL_NP","Komuna nabari du");    /* version 0.9.1 */
+define("LABEL_NA","Irismen nabari du");   /* version 0.9.1 */
+define("LABEL_NP","Komuna nabari du"); /* version 0.9.1 */
 define("LABEL_EditorNota","NotenEditorea");
 define("LABEL_EditorNotaTermino","TerminoarenNotak ");
 define("LABEL_tipoNota","Bikain tipoa");
 define("FORM_LABEL_tipoNota","Bikain_tipoa");
 define("LABEL_nota","Bikain");
 define("FORM_LABEL_nota","_Bikain");
+define("LABEL_EditarNota","Nota editatzea");
 define("LABEL_EliminarNota","Nota eliminatzea");
 define("LABEL_OptimizarTablas","Taulak optimizatzea");
 define("LABEL_TotalZthesLine","Esportatzea Zthes");
@@ -150,24 +151,24 @@ define("LABEL_terminosRepetidos","Repetido terminoak");
 define("MSG_noTerminosLibres","Termino askeak ez dira existitzen");
 define("MSG_noTerminosRepetidos","Repetido terminoak ez dira existitzen");
 define("LABEL_TotalSkosLine","Esportatzea Skos-Core");
-$MONTHS=array("01"=>Urtarri,
-              "02"=>Otsail,
-              "03"=>Martxo,
-              "04"=>Apiril,
-              "05"=>Maiatz,
-              "06"=>Ekain,
-              "07"=>Uztail,
-              "08"=>Abutzu,
-              "09"=>Irail,
-              "10"=>Urri,
-              "11"=>Azaro,
-              "12"=>Abendu
+$MONTHS=array("01"=>"Jan",
+              "02"=>"Feb",
+              "03"=>"Mar",
+              "04"=>"Apr",
+              "05"=>"May",
+              "06"=>"Jun",
+              "07"=>"Jul",
+              "08"=>"Ago",
+              "09"=>"Sep",
+              "10"=>"Oct",
+              "11"=>"Nov",
+              "12"=>"Dec"
               );
 /* v 9.4 */
 define("LABEL_SI","BAI");
 define("LABEL_NO","EZ");
 define("FORM_LABEL_jeraquico","Polijerarquia");
-define("LABEL_jeraquico","Polijerarquia");
+define("LABEL_jeraquico","Polijerarquia"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","Termino askea");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Bilatzea: ");
@@ -183,24 +184,22 @@ define("LABEL_tipo_vocabulario","Tipoa");
 define("LABEL_termino_equivalente","Baliokide da");
 define("LABEL_termino_parcial_equivalente","Era partzialean baliokide da");
 define("LABEL_termino_no_equivalente","Ez baliokide da");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Katalogazioaren nabari du");
 define("LABEL_resultados_suplementarios","Ondorio betegarriak");
 define("LABEL_resultados_relacionados","Ondorio erlazionatuak");
 /* v 9.7 */
 define("LABEL_export","Esportatzea");
 define("FORM_LABEL_format_export","Formatua aukeratzea");
-define("LABEL_siteMap","Gunearen mapa");
-define("LABEL_TotalTopicMap","Esportatzea TopicMap");
 /* v 1.0 */
 define("LABEL_fecha_creacion","Sortuta");
-define("NB_acronimo","NB");
-define("NH_acronimo","NH");
-define("NA_acronimo","NA");
-define("NP_acronimo","NP");
-define("NC_acronimo","NC");
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NA"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","Hautagai terminoa");
 define("LABEL_Aceptado","Termino onartua");
 define("LABEL_Rechazado","Termino errefusatua");
@@ -211,6 +210,7 @@ define("LABEL_Aceptados","Termino onartuak");
 define("LABEL_Rechazados","Termino onartuak");
 define("LABEL_User_NoHabilitado","Prestatuta ez");
 define("LABEL_User_Habilitado","Prestatuta");
+
 define("LABEL_CandidatearTermino","Hautagai estatua pasatzea");
 define("LABEL_AceptarTermino","Terminoa onartzea");
 define("LABEL_RechazarTermino","Terminoa errefusatzea");
@@ -239,15 +239,15 @@ define("PARAM_DBName","Database name") ;
 define("PARAM_DBLogin","Database User") ;
 define("PARAM_DBPass","Database Password") ;
 define("PARAM_DBprefix","Prefix tables") ;
-$install_message[101] = "Instalación de TemaTres" ;
-$install_message[201] = "No se encuentra el archivo de configuración de la base de datos (%s) hay archivo." ;
-$install_message[202] = "Archivo de configuración de la base de datos encontrado." ;
-$install_message[203] = "No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)" ;
-$install_message[204] = "Conexión con el servidor <em>%s</em> exitosa" ;
-$install_message[205] = "No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)." ;
-$install_message[206] = "Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada." ;
-$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = "Indiación acerca del grado de seguridad de la clave." ;
+$install_message[101] = 'Instalación de TemaTres' ;
+$install_message[201] = 'No se encuentra el archivo de configuración de la base de datos (%s) hay archivo.';
+$install_message[202] = 'Archivo de configuración de la base de datos encontrado.';
+$install_message[203] = 'No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)';
+$install_message[204] = 'Conexión con el servidor <em>%s</em> exitosa';
+$install_message[205] = 'No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s).';
+$install_message[206] = 'Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada.' ;
+$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. Por favor, compruebe su configuración de archivo para la conexión de base de datos (%s) o <a href="index.php">Comience a utilizar su vocabulario</a>' ;
+$install_message[305] = 'Indiación acerca del grado de seguridad de la clave.' ;
 $install_message[306] = 'Instalación completa, <a href="index.php">comience a utilizar su vocabulario</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -266,7 +266,7 @@ define('LABEL_BusquedaAvanzada',"búsqueda avanzada");
 define('LABEL_Todos',"todos");
 define('LABEL_QueBuscar',"¿Qué buscar?");
 define("LABEL_import","Importar") ;
-define("IMPORT_form_legend","Importar un archivo de texto tabulado ") ;
+define("IMPORT_form_legend","Importar un archivo de texto") ;
 define("IMPORT_form_label","Archivo") ;
 define("IMPORT_file_already_exists","Un archivo txt ya está presente en el servidor") ;
 define("IMPORT_file_not_exists","No hay archivos todavía") ;
@@ -274,11 +274,11 @@ define("IMPORT_do_it","Puede iniciar la importación") ;
 define("IMPORT_working","proceso de importanción en marcha") ;
 define("IMPORT_finish","importación finalizada") ;
 define("LABEL_reIndice","Recrear índices de términos") ;
-define("LABEL_dbMantenimiento","Mantenimiento de la base de datos") ;
+define("LABEL_dbMantenimiento","Mantenimiento de la base de datos");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
-define('LABEL_relacion_vocabularioWebService',"Relación con un término de otro vocabulario");
+define('LABEL_relacion_vocabularioWebService',"relation with term from remote target vocabulary");
 define('LABEL_vocabulario_referenciaWS',"Vocabulario externo vía servicios web");
 define('LABEL_TargetVocabularyWS',"Vocabulario externo vía servicios web");
 define('LABEL_tvocab_label',"leyenda de la referencia");
@@ -286,14 +286,14 @@ define('LABEL_tvocab_tag',"etiqueta de la referencia");
 define('LABEL_tvocab_uri_service',"URL del servicio web de referencia");
 define('LABEL_targetTermsforUpdate',"términos con actualizaciones pendientes");
 define('LABEL_ShowTargetTermsforUpdate',"actualizar términos");
-define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_enable',"habilitado");
 define('LABEL_disable',"deshabilitado");
 define('LABEL_notFound',"término no encontrado");
 define('LABEL_termUpdated',"término actualizado");
+define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_relbetweenVocabularies',"relaciones entre vocabularios");
-define('LABEL_update1_1x1_2',"Actualizar Tematres (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"Actualizar Tematres (1.0x -> 1.3)");
+define('LABEL_update1_1x1_2',"Actualizar (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Actualizar (1.0x -> 1.3)");
 define('LABEL_TargetTerm',"término externo (mapeo terminológico)");
 define('LABEL_TargetTerms',"términos externos (mapeo terminológico)");
 define('LABEL_seleccionar','seleccionar');
@@ -332,7 +332,7 @@ define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','cantidad de términos para visualizaci
 define('LABEL_CFG_MIN_SEARCH_SIZE','número mínimo de caracteres para operaciones de búsqueda');
 define('LABEL__SHOW_TREE','publicar navegación jerárquica en página de inicio');
 define('LABEL__PUBLISH_SKOS','permitir consultas SKOS-core a través de servicios web. Esto podría exponer todo su vocabulario.');
-define('LABEL_update1_3x1_4',"Actualizar Tematres (1.3x -> 1.4)");
+define('LABEL_update1_3x1_4',"Actualizar (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","seleccionar formato");
 define("LABEL_importTab","texto tabulado");
 define("LABEL_importTag","texto etiquetado");
@@ -450,7 +450,7 @@ define('LABEL_defaultEQmap','Utilice "eq" para indicar relación de equivalencia
 define("MSG_repass_error","las claves no coinciden");
 define("MSG_lengh_error","mínimo de %d caracteres");
 define("MSG_errorPostData","Ha ocurrido un error, por favor revise los datos correspondiente al campo ");
-define('LABEL_preferedTerms','términos preferidos');
+define('LABEL_preferedTerms','términos preferidos');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','términos SIN notas');
 define('MSG_FORM_NULLnotesTermReport','términos que no tienen notas de tipo');
 define('LABELnoNotes','términos sin ninguna nota');
@@ -501,6 +501,14 @@ define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término s
 define('LABEL_opt_show_rando_term','presentar términos con nota:');
 define('MSG_helpNoteEditor','Puede vincular términos utilizando corchetes dobles. Ej: Sólo el [[amor]] salvará el mundo');
 define('LABEL_GLOSS_NOTES','Seleccionar tipo de nota para glosar términos marcados con corchetes dobles: [[glosario]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referencias');
@@ -513,4 +521,11 @@ define('LABEL_termsNoEQ','sin correspondencias');
 define('LABEL_close','cerrar');
 define('LABEL_allTerms','todos los términos');
 define('LABEL_allNotes','todas las notas');
-define('LABEL_allRelations','todas las relaciones entre términos');?>
+define('LABEL_allRelations','todas las relaciones entre términos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
+?>

--- a/common/lang/fr-utf-8.inc.php
+++ b/common/lang/fr-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
-#   Author for this i18n: Rachel Cervera & Olivier De Mey
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","fr");
-define("TR_acronimo","TA"); /*Terme associé*/
-define("TE_acronimo","TS"); /*Terme spécifique*/
-define("TG_acronimo","TG"); /*Terme générique*/
-define("UP_acronimo","EP"); /*Employé pour*/
+define("TR_acronimo","TA"); /* Related Term */
+define("TE_acronimo","TS"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","EP"); /* Used for > instead */
 define("TR_termino","Terme associé");
 define("TE_termino","Terme spécifique");
 define("TG_termino","Terme générique");
-define("UP_termino","Employé pour");
+define("UP_termino","Employé pour"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","EM");
+define("USE_termino","EM"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Liste thématique");
 define("MENU_ListaAbc","Liste alphabétique");
 define("MENU_Sobre","A propos de...");
@@ -31,11 +32,11 @@ define("MENU_BorrarT","Supprimer");
 define("MENU_AgregarTG","Subordonner à un terme");
 define("MENU_AgregarTE","Terme spécifique");
 define("MENU_AgregarTR","Terme associé");
-define("MENU_AgregarUP","Terme non-préférentiel");
+define("MENU_AgregarUP","Terme non-préférentiel");  /* Non-descriptor */
 define("MENU_MisDatos","Mon compte");
-define("MENU_Caducar","Expirer"); 
-define("MENU_Habilitar","Autoriser"); 
-define("MENU_Salir","Déconnexion"); 
+define("MENU_Caducar","Expirer");
+define("MENU_Habilitar","Autoriser");
+define("MENU_Salir","Déconnexion");
 define("LABEL_Menu","Menu");
 define("LABEL_Opciones","Options");
 define("LABEL_Admin","Administration");
@@ -44,14 +45,13 @@ define("LABEL_editT","Édition du terme ");
 define("LABEL_EditorTermino","Editeur de termes");
 define("LABEL_Termino","Terme");
 define("LABEL_NotaAlcance","note d'application");
+define("LABEL_EliminarTE","Supprimer");
 define("LABEL_AgregarT","Ajout d'un ou plusieurs termes");
-define("LABEL_AgregarTG","Ajouter un terme générique à ");
+define("LABEL_AgregarTG","Ajouter un terme générique à %s ");
 define("LABEL_AgregarTE","Ajouter un terme spécifique à ");
 define("LABEL_AgregarUP","Ajouter un terme non-préférentiel à ");
 define("LABEL_AgregarTR","Ajouter un terme associé à ");
-define("LABEL_EliminarTE","Supprimer");
 define("LABEL_Detalle","détails");
-define("LABEL_EditarNota","Éditer");
 define("LABEL_Autor","Auteur");
 define("LABEL_URI","URI");
 define("LABEL_Version","Réalisé avec");
@@ -69,11 +69,11 @@ define("LABEL_Enviar","Valider");
 define("LABEL_Cambiar","Enregistrer les modifications");
 define("LABEL_Anterior"," ◄ Page précédente");
 define("LABEL_AdminUser","Administration des utilisateurs");
-define("LABEL_DatosUser","Profil de l'utilisateur"); 
+define("LABEL_DatosUser","Profil de l'utilisateur");
 define("LABEL_Acciones","Tâches réalisées");
 define("LABEL_verEsquema","voir le schéma");
 define("LABEL_actualizar","Mise à jour");
-define("LABEL_terminosLibres","termes libres"); /* 'Terme libre' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in Tematres. Note: 'orphelin' (orphan) is not good either as it means 'not preferred' */
+define("LABEL_terminosLibres","termes libres"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Recherche");
 define("LABEL_borraRelacion","Supprimer la relation");
 define("MSG_ResultBusca","terme(s) trouvé(s) lors de la recherche");
@@ -120,14 +120,15 @@ define("LABEL_verDetalle","voir les détails de ");
 define("LABEL_verTerminosLetra","voir les termes commençant par ");
 define("LABEL_NB","Note bibliographique");
 define("LABEL_NH","Note historique");
-define("LABEL_NA","Note d'application"); /* version 0.9.1 Note d'application */
-define("LABEL_NP","Note privée");    /* version 0.9.1 */
+define("LABEL_NA","Note d'application");   /* version 0.9.1 */
+define("LABEL_NP","Note privée"); /* version 0.9.1 */
 define("LABEL_EditorNota","Éditer une note");
 define("LABEL_EditorNotaTermino","Note du terme ");
 define("LABEL_tipoNota","type");
 define("FORM_LABEL_tipoNota","type_note");
 define("LABEL_nota","note");
 define("FORM_LABEL_nota","_note");
+define("LABEL_EditarNota","Éditer");
 define("LABEL_EliminarNota","Supprimer la note");
 define("LABEL_OptimizarTablas","Optimiser les tables");
 define("LABEL_TotalZthesLine","Thésaurus complet en Zthes");
@@ -167,7 +168,7 @@ $MONTHS=array("01"=>"Jan",
 define("LABEL_SI","OUI");
 define("LABEL_NO","NON");
 define("FORM_LABEL_jeraquico","polyhiérarchie");
-define("LABEL_jeraquico","Autoriser qu'un terme puisse appartenir à plusieurs termes génériques");
+define("LABEL_jeraquico","Polyhiérarchie"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","terme libre");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Rechercher %s en: ");
@@ -183,9 +184,9 @@ define("LABEL_tipo_vocabulario","type de vocabulaire");
 define("LABEL_termino_equivalente","équivalent");
 define("LABEL_termino_parcial_equivalente","partiellement équivalent");
 define("LABEL_termino_no_equivalente","non équivalent");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","PEQ");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","PEQ"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Note du catalogueur");
 define("LABEL_resultados_suplementarios","résultats supplémentaires");
 define("LABEL_resultados_relacionados","résultats associés");
@@ -194,11 +195,11 @@ define("LABEL_export","export / Publication");
 define("FORM_LABEL_format_export","Format du fichier");
 /* v 1.0 */
 define("LABEL_fecha_creacion","created");
-define("NB_acronimo","NB"); /* Note bibliographique */
-define("NH_acronimo","NH");/* Note historique */
-define("NA_acronimo","NA"); /* Note d'application */
-define("NP_acronimo","NP"); /* Note privée */
-define("NC_acronimo","NC"); /* Note du catalogueur */
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NE"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","terme candidat");
 define("LABEL_Aceptado","terme accepté");
 define("LABEL_Rechazado","terme rejeté");
@@ -209,7 +210,7 @@ define("LABEL_Aceptados","termes acceptés");
 define("LABEL_Rechazados","termes rejetés");
 define("LABEL_User_NoHabilitado","compte inactif");
 define("LABEL_User_Habilitado","compte actif");
-// define("LABEL_CandidatearTermino","Candidatear término");
+
 define("LABEL_CandidatearTermino","Proposer le terme comme candidat");
 define("LABEL_AceptarTermino","Accepter le terme");
 define("LABEL_RechazarTermino","Rejeter le terme");
@@ -223,7 +224,7 @@ define("LABEL_Guardar","Enregistrer");
 define("MENU_AgregarTEexist","Subordinate An Existing Term");
 define("MENU_AgregarUPexist","Associate An Existing Non-Preferred Term");
 define("LABEL_existAgregarUP","Add UF term to %s");
-define("LABEL_existAgregarTE","Add narrow Term to %s ");
+define("LABEL_existAgregarTE","Add narrower term to %s ");
 define("MSG_minCharSerarch","The search expression <i>%s</i> has only <strong>%s </strong> characters. Must be greater than <strong>%s</strong> characters");
 /* v 1.04 */
 define("LABEL_terminoExistente","terme existant");
@@ -238,15 +239,15 @@ define("PARAM_DBName","Nom de la base de données") ;
 define("PARAM_DBLogin","Nom d'utilisateur pour la base de données") ;
 define("PARAM_DBPass","Mot de passe pour la base de données") ;
 define("PARAM_DBprefix","Préfixe pour les tables") ;
-$install_message[101] = "Installation de TemaTres " ;
-$install_message[201] = "Configuration du fichier pour la connection à la base de données introuvable (%s) !" ;
-$install_message[202] = "Configuration du fichier pour la connection à la base de donnée détectée !" ;
-$install_message[203] = "Connexion au serveur de bases de données <em>%s</em> impossible avec l'utilisateur <em>%s</em> ! Veuillez vérifier la configuration du fichier pour la connection à la base de données (%s)." ;
-$install_message[204] = "Connexion au serveur <em>%s</em> réussie !" ;
-$install_message[205] = "Connection à la base de données <em>%s</em> du serveur <em>%s</em> impossible ! Veuillez vérifier la configuration du fichier pour la connection à la base de données (%s)." ;
+$install_message[101] = 'Installation de TemaTres ' ;
+$install_message[201] = 'Configuration du fichier pour la connection à la base de données introuvable (%s) !';
+$install_message[202] = 'Configuration du fichier pour la connection à la base de donnée détectée !';
+$install_message[203] = 'Connexion au serveur de bases de données <em>%s</em> impossible avec l\'utilisateur <em>%s</em> ! Veuillez vérifier la configuration du fichier pour la connection à la base de données (%s).';
+$install_message[204] = 'Connexion au serveur <em>%s</em> réussie !';
+$install_message[205] = 'Connection à la base de données <em>%s</em> du serveur <em>%s</em> impossible ! Veuillez vérifier la configuration du fichier pour la connection à la base de données (%s).';
+$install_message[206] = 'Connection à la base de données <em>%s</em> du serveur <em>%s</em> réussie !' ;
 $install_message[301] = 'Grrr... Il y a déjà une instance Tematres pour cette configuration. Veuillez vérifier la configuration du fichier pour la connexion à la base de données (%s) ou <a href="index.php">Accéder à votre serveur Tematres</a>' ;
-$install_message[206] = "Connection à la base de données <em>%s</em> du serveur <em>%s</em> réussie !" ;
-$install_message[305] = " Verification du mot de passe de sécurité en cours." ;
+$install_message[305] = ' Verification du mot de passe de sécurité en cours.' ;
 $install_message[306] = 'Installation terminée ! <a href="index.php">Accéder à votre serveur Tematres</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -256,16 +257,16 @@ define('LABEL_Ver',"Afficher");
 define('LABEL_OpcionesTermino',"terme");
 define('LABEL_CambiarEstado',"Changer le statut");
 define('LABEL_ClickEditar',"Cliquez pour éditer...");
-define('LABEL_TopTerm',"Terme de tête"); /*Has this top term*/
+define('LABEL_TopTerm',"Terme de tête");
 define('LABEL_esFraseExacta',"expression exacte");
 define('LABEL_DesdeFecha',"créé en ... ou après");
 define('LABEL_ProfundidadTermino',"est situé au niveau");
-define('LABEL_esNoPreferido',"Terme non-préférentiel");/*non preferred term*/
+define('LABEL_esNoPreferido',"Terme non-préférentiel");
 define('LABEL_BusquedaAvanzada',"recherche avancée");
 define('LABEL_Todos',"- - - -");
 define('LABEL_QueBuscar',"Critère de recherche");
 define("LABEL_import","Importer") ;
-define("IMPORT_form_legend","Importer un thésaurus indenté") ;
+define("IMPORT_form_legend","Importer un thésaurus à partir d'un fichier") ;
 define("IMPORT_form_label","Fichier") ;
 define("IMPORT_file_already_exists","Un fichier txt est déjà présent sur le serveur") ;
 define("IMPORT_file_not_exists","Aucun fichier à importer pour le moment") ;
@@ -273,16 +274,16 @@ define("IMPORT_do_it","Vous pouvez lancer l'import") ;
 define("IMPORT_working","suite automatique en cours") ;
 define("IMPORT_finish","Fin de l'insertion") ;
 define("LABEL_reIndice","recréer les index") ;
-define("LABEL_dbMantenimiento","base de données") ;
+define("LABEL_dbMantenimiento","base de données");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
-define('LABEL_relacion_vocabularioWebService',"Lier à un terme d\'un vocabulaire distant");
-define('LABEL_vocabulario_referenciaWS',"vocabulaire distant (service web)");/* remote target vocabulary */
+define('LABEL_relacion_vocabularioWebService',"Lier à un terme d\\'un vocabulaire distant");
+define('LABEL_vocabulario_referenciaWS',"vocabulaire distant (service web)");
 define('LABEL_TargetVocabularyWS',"vocabulaire distant (services web)");
 define('LABEL_tvocab_label',"intitulé de la référence");
 define('LABEL_tvocab_tag',"étiquette p");
-define('LABEL_tvocab_uri_service',"URL du service web"); /* URL for the web services reference */
+define('LABEL_tvocab_uri_service',"URL du service web");
 define('LABEL_targetTermsforUpdate',"termes à Mise à jour");
 define('LABEL_ShowTargetTermsforUpdate',"vérifier les mises à jour");
 define('LABEL_enable',"activer");
@@ -433,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relations entre vocabulaires');
 define('LABEL_eliminar','Supprimer');
 ##v.2
-define('MSG_termsNoDeleted','le terme a été effacé.');
+define('MSG_termsNoDeleted','le terme n\'a pas été effacé');
 define('MSG_termsDeleted','terme(s) supprimé(s)');
 define('LABEL_selectAll','Sélectionner tout');
 define('LABEL_metadatos','métadonnées');
@@ -449,7 +450,7 @@ define('LABEL_defaultEQmap','Taper "eq" pour définir une relation d\'équivalen
 define("MSG_repass_error","les deux mots de passe ne correspondent pas");
 define("MSG_lengh_error","%d caractères minimum");
 define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','termes préférentiels');
+define('LABEL_preferedTerms','termes préférentiels');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','termes sans notes');
 define('MSG_FORM_NULLnotesTermReport','termes sans note de type');
 define('LABELnoNotes','termes sans aucune note');
@@ -476,7 +477,7 @@ define('LABEL_termMOD','terme après modification');
 define('LABEL_noteMOD','note après modification');
 define('MENU_bulkEdition','Édition en masse');
 define('MSG_searchFor','La recherche est sensible à la casse');
-define('MSG_replaceWith','');
+define('MSG_replaceWith','Input text you want to replace with (case sensitive)');
 define('LABEL_warningBulkEditor','Vous êtes sur le point de modifier des données en masse. Cette action est irréversible !');
 define('LABEL_CFG_SUGGESTxWORD','suggérer les terms par mots ou expressions');
 define('LABEL_ALLOW_DUPLICATED','Autoriser les termes en doublon');
@@ -496,7 +497,7 @@ define('MSG__GLOSSincludeAltLabel','inclure les termes non-préférentiels');
 define('MSG__GLOSSdocumentationJSON','Avec ce fichier JSON et <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>, vous pouvez intégrer votre glossaire à n\'importe quelle page web.');
 define('LABEL_configGlossary','Télécharger le glossaire');
 define('MSG_includeNotes','types de notes contenant les définitions à inclure dans le glossaire.');
-define('LABEL_SHOW_RANDOM_TERM','afficher sur la page d\'accueil un terme choisi au hasard'); /* presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.*/
+define('LABEL_SHOW_RANDOM_TERM','afficher sur la page d\'accueil un terme choisi au hasard');
 define('LABEL_opt_show_rando_term','montrer des termes ayant une note de type');
 define('MSG_helpNoteEditor','Utilisez une double paire de crochets pour faire un lien vers d\'autres termes. Exemple : L\'argent est [[roi]].');
 define('LABEL_GLOSS_NOTES','Type des notes utilisées pour définir les [[termes placés entre une double paire de crochets]]');
@@ -506,11 +507,12 @@ define('MSG__autoGlossDanger','Cette opération étant irréversible, il est con
 define('LABEL_replaceBinary','sensible à la casse');
 define('MSG_notesAffected','notes modifiées');
 define('MSG_cantTermsFound','termes trouvés');
-define('MENU_glossConfig','Glossaire');
+define('MENU_glossConfig','Glossaire'); /* Used as menu entry. Keep it short */ 
 define('LABEL_generateAutoGlossary','Ajouter des liens dans les notes');
 define('LABEL_AlphaPDF','alphabétique (PDF)');
+define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','références');
-define('LABEL_printData','date d\impression');
+define('LABEL_printData','date d\'impression');
 ##v.3
 define('MENU_bulkTranslate','multilingual editor');
 define('LABEL_bulkTranslate','mapping and multilingual editor');
@@ -520,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/gl-utf-8.inc.php
+++ b/common/lang/gl-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 0.97
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","gl");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Termo relacionado");
 define("TE_termino","Termo específico");
 define("TG_termino","Termo xeral");
-define("UP_termino","Usado por");
+define("UP_termino","Usado por"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USE");
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Lista sistemática");
 define("MENU_ListaAbc","Lista alfabética");
 define("MENU_Sobre","Sobre...");
@@ -31,7 +32,7 @@ define("MENU_BorrarT","eliminar Termo");
 define("MENU_AgregarTG","subordinar a un termo");
 define("MENU_AgregarTE","termo subordinado");
 define("MENU_AgregarTR","termo relacionado");
-define("MENU_AgregarUP","termo equivalente");
+define("MENU_AgregarUP","termo equivalente");  /* Non-descriptor */
 define("MENU_MisDatos","Os meus datos");
 define("MENU_Caducar","Caducar");
 define("MENU_Habilitar","Habilitar");
@@ -44,14 +45,13 @@ define("LABEL_editT","Modificar termo");
 define("LABEL_EditorTermino","Editor de termo");
 define("LABEL_Termino","Termo");
 define("LABEL_NotaAlcance","Nota de alcance");
+define("LABEL_EliminarTE","Eliminar termo");
 define("LABEL_AgregarT","Alta de termo");
 define("LABEL_AgregarTG","Subordinar a termo superior");
 define("LABEL_AgregarTE","Alta dun termo subordinado a");
 define("LABEL_AgregarUP","Alta dun termo equivalente para  ");
 define("LABEL_AgregarTR","Alta de termo relacionado con");
-define("LABEL_EliminarTE","Eliminar termo");
 define("LABEL_Detalle","detalles");
-define("LABEL_EditarNota","editar nota");
 define("LABEL_Autor","Autor");
 define("LABEL_URI","URI");
 define("LABEL_Version","Xerado por");
@@ -73,7 +73,7 @@ define("LABEL_DatosUser","Datos do usuario");
 define("LABEL_Acciones","Accións realizadas");
 define("LABEL_verEsquema","ver esquema");
 define("LABEL_actualizar","Actualizar");
-define("LABEL_terminosLibres","Termos libres");
+define("LABEL_terminosLibres","Termos libres"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Procura");
 define("LABEL_borraRelacion","eliminar relación");
 define("MSG_ResultBusca","termos atopados para a procura");
@@ -120,14 +120,15 @@ define("LABEL_verDetalle","ver detalles de ");
 define("LABEL_verTerminosLetra","ver termos iniciados con ");
 define("LABEL_NB","Nota bibliográfica");
 define("LABEL_NH","Nota histórica");
-define("LABEL_NA","Nota de alcance"); /* version 0.9.1 */
-define("LABEL_NP","Nota privada");    /* version 0.9.1 */
+define("LABEL_NA","Nota de alcance");   /* version 0.9.1 */
+define("LABEL_NP","Nota privada"); /* version 0.9.1 */
 define("LABEL_EditorNota","Editor de notas");
 define("LABEL_EditorNotaTermino","Notas do termo ");
 define("LABEL_tipoNota","tipo de nota");
 define("FORM_LABEL_tipoNota","tipo_nota");
 define("LABEL_nota","nota");
 define("FORM_LABEL_nota","_nota");
+define("LABEL_EditarNota","editar nota");
 define("LABEL_EliminarNota","Eliminar nota");
 define("LABEL_OptimizarTablas","Optimizar táboas");
 define("LABEL_TotalZthesLine","exportar en Zthes");
@@ -150,24 +151,24 @@ define("LABEL_terminosRepetidos","térmos repetidos");
 define("MSG_noTerminosLibres","non existen termos libres");
 define("MSG_noTerminosRepetidos","non existen termos repetidos");
 define("LABEL_TotalSkosLine","exportar en Skos-Core");
-$MONTHS=array("01"=>Xaneiro,
-              "02"=>Febreiro,
-              "03"=>Marzo,
-              "04"=>Abril,
-              "05"=>Maio,
-              "06"=>Xuño,
-              "07"=>Xulio,
-              "08"=>Agosto,
-              "09"=>Setembro,
-              "10"=>Outubro,
-              "11"=>Novembro,
-              "12"=>Decembro
+$MONTHS=array("01"=>"Jan",
+              "02"=>"Feb",
+              "03"=>"Mar",
+              "04"=>"Apr",
+              "05"=>"May",
+              "06"=>"Jun",
+              "07"=>"Jul",
+              "08"=>"Ago",
+              "09"=>"Sep",
+              "10"=>"Oct",
+              "11"=>"Nov",
+              "12"=>"Dec"
               );
 /* v 9.4 */
 define("LABEL_SI","SI");
 define("LABEL_NO","NON");
 define("FORM_LABEL_jeraquico","polijerarquia");
-define("LABEL_jeraquico","Polijerarquía");
+define("LABEL_jeraquico","Polijerarquía"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","tErmo libre");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Buscar %s en: ");
@@ -183,24 +184,22 @@ define("LABEL_tipo_vocabulario","tipo");
 define("LABEL_termino_equivalente","equivale");
 define("LABEL_termino_parcial_equivalente","equivale parcialmente");
 define("LABEL_termino_no_equivalente","non equivale");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota de catalogación");
 define("LABEL_resultados_suplementarios","resultados suplementarios");
 define("LABEL_resultados_relacionados","resultados relacionados");
 /* v 9.7 */
 define("LABEL_export","exportar");
 define("FORM_LABEL_format_export","seleccionar formato");
-define("LABEL_siteMap","SiteMap");
-define("LABEL_TotalTopicMap","exportar en TopicMap");
 /* v 1.0 */
 define("LABEL_fecha_creacion","creado");
-define("NB_acronimo","NB");
-define("NH_acronimo","NH");
-define("NA_acronimo","NA");
-define("NP_acronimo","NP");
-define("NC_acronimo","NC");
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NA"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","termo candidato");
 define("LABEL_Aceptado","termo aceptado");
 define("LABEL_Rechazado","termo rexeitado");
@@ -211,6 +210,7 @@ define("LABEL_Aceptados","termos aceptados");
 define("LABEL_Rechazados","termos rexeitados");
 define("LABEL_User_NoHabilitado","non habilitado");
 define("LABEL_User_Habilitado","habilitado");
+
 define("LABEL_CandidatearTermino","Pasar a estado candidato");
 define("LABEL_AceptarTermino","Aceptar termo");
 define("LABEL_RechazarTermino","Rexeitar termo");
@@ -239,15 +239,15 @@ define("PARAM_DBName","Database name") ;
 define("PARAM_DBLogin","Database User") ;
 define("PARAM_DBPass","Database Password") ;
 define("PARAM_DBprefix","Prefix tables") ;
-$install_message[101] = "Instalación de TemaTres" ;
-$install_message[201] = "No se encuentra el archivo de configuración de la base de datos (%s) hay archivo." ;
-$install_message[202] = "Archivo de configuración de la base de datos encontrado." ;
-$install_message[203] = "No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)" ;
-$install_message[204] = "Conexión con el servidor <em>%s</em> exitosa" ;
-$install_message[205] = "No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)." ;
-$install_message[206] = "Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada." ;
-$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = "Indiación acerca del grado de seguridad de la clave." ;
+$install_message[101] = 'Instalación de TemaTres' ;
+$install_message[201] = 'No se encuentra el archivo de configuración de la base de datos (%s) hay archivo.';
+$install_message[202] = 'Archivo de configuración de la base de datos encontrado.';
+$install_message[203] = 'No es posible conectar con el servidor <em>%s</em> utilizando el usuario <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s)';
+$install_message[204] = 'Conexión con el servidor <em>%s</em> exitosa';
+$install_message[205] = 'No es posible conectar con la base de datos <em>%s</em> en <em>%s</em>. Por favor revise los datos del archivo de configuración de la base de datos (%s).';
+$install_message[206] = 'Conexión con la base de datos <em>%s</em> en <em>%s</em> verificada.' ;
+$install_message[301] = 'Parece que las tablas ya han sido creadas para la configuración establecida. Por favor, compruebe su configuración de archivo para la conexión de base de datos (%s) o <a href="index.php">Comience a utilizar su vocabulario</a>' ;
+$install_message[305] = 'Indiación acerca del grado de seguridad de la clave.' ;
 $install_message[306] = 'Instalación completa, <a href="index.php">comience a utilizar su vocabulario</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -266,7 +266,7 @@ define('LABEL_BusquedaAvanzada',"búsqueda avanzada");
 define('LABEL_Todos',"todos");
 define('LABEL_QueBuscar',"¿Qué buscar?");
 define("LABEL_import","Importar") ;
-define("IMPORT_form_legend","Importar un archivo de texto tabulado ") ;
+define("IMPORT_form_legend","Importar un archivo de texto") ;
 define("IMPORT_form_label","Archivo") ;
 define("IMPORT_file_already_exists","Un archivo txt ya está presente en el servidor") ;
 define("IMPORT_file_not_exists","No hay archivos todavía") ;
@@ -274,7 +274,7 @@ define("IMPORT_do_it","Puede iniciar la importación") ;
 define("IMPORT_working","proceso de importanción en marcha") ;
 define("IMPORT_finish","importación finalizada") ;
 define("LABEL_reIndice","Recrear índices de términos") ;
-define("LABEL_dbMantenimiento","Mantenimiento de la base de datos") ;
+define("LABEL_dbMantenimiento","Mantenimiento de la base de datos");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -286,13 +286,13 @@ define('LABEL_tvocab_tag',"etiqueta de la referencia");
 define('LABEL_tvocab_uri_service',"URL del servicio web de referencia");
 define('LABEL_targetTermsforUpdate',"términos con actualizaciones pendientes");
 define('LABEL_ShowTargetTermsforUpdate',"actualizar términos");
-define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_enable',"habilitado");
 define('LABEL_disable',"deshabilitado");
 define('LABEL_notFound',"término no encontrado");
 define('LABEL_termUpdated',"término actualizado");
+define('LABEL_ShowTargetTermforUpdate',"actualizar");
 define('LABEL_relbetweenVocabularies',"relaciones entre vocabularios");
-define('LABEL_update1_1x1_2',"Actualizar Tematres (1.1 -> 1.3)");
+define('LABEL_update1_1x1_2',"Actualizar (1.1 -> 1.3)");
 define('LABEL_update1x1_2',"Actualizar Tematres (1.0x -> 1.3)");
 define('LABEL_TargetTerm',"término externo (mapeo terminológico)");
 define('LABEL_TargetTerms',"términos externos (mapeo terminológico)");
@@ -450,7 +450,7 @@ define('LABEL_defaultEQmap','Utilice "eq" para indicar relación de equivalencia
 define("MSG_repass_error","las claves no coinciden");
 define("MSG_lengh_error","mínimo de %d caracteres");
 define("MSG_errorPostData","Ha ocurrido un error, por favor revise los datos correspondiente al campo ");
-define('LABEL_preferedTerms','términos preferidos');
+define('LABEL_preferedTerms','términos preferidos');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','términos SIN notas');
 define('MSG_FORM_NULLnotesTermReport','términos que no tienen notas de tipo');
 define('LABELnoNotes','términos sin ninguna nota');
@@ -501,6 +501,14 @@ define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término s
 define('LABEL_opt_show_rando_term','presentar términos con nota:');
 define('MSG_helpNoteEditor','Puede vincular términos utilizando corchetes dobles. Ej: Sólo el [[amor]] salvará el mundo');
 define('LABEL_GLOSS_NOTES','Seleccionar tipo de nota para glosar términos marcados con corchetes dobles: [[glosario]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referencias');
@@ -513,4 +521,11 @@ define('LABEL_termsNoEQ','sin correspondencias');
 define('LABEL_close','cerrar');
 define('LABEL_allTerms','todos los términos');
 define('LABEL_allNotes','todas las notas');
-define('LABEL_allRelations','todas las relaciones entre términos');?>
+define('LABEL_allRelations','todas las relaciones entre términos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
+?>

--- a/common/lang/it-utf-8.inc.php
+++ b/common/lang/it-utf-8.inc.php
@@ -1,20 +1,23 @@
 <?php
-#   TemaTres : applicazione per la gestione di linguaggi documentali #       #
-#   Author for this i18n: Andrea Garelli - revisione 2013: Paolo Plini
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","it");
-define("TR_acronimo","RT");   // conforme iso 2788
-define("TE_acronimo","NT");   // conforme iso 2788
-define("TG_acronimo","BT");   // conforme iso 2788
-define("UP_acronimo","UF");   // conforme iso 2788
+define("TR_acronimo","RT"); /* Related Term */
+define("TE_acronimo","NT"); /* Narrower term > Specific term */
+define("TG_acronimo","BT"); /* Broader term > Generic term */
+define("UP_acronimo","UF"); /* Used for > instead */
 define("TR_termino","Termine associato ");
 define("TE_termino","Termine pi&ugrave; specifico ");
 define("TG_termino","Termine pi&ugrave; generico ");
-define("UP_termino","Usa per ");
+define("UP_termino","Usa per "); /* A term with this symbol is followed by non preferred terms (non descriptors) */
+/* v 9.5 */
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Elenco sistematico");
 define("MENU_ListaAbc","Elenco alfabetico");
 define("MENU_Sobre","Info...");
@@ -27,9 +30,9 @@ define("MENU_AgregarT","Aggiungi termine");
 define("MENU_EditT","Modifica termine");
 define("MENU_BorrarT","Cancella termine");
 define("MENU_AgregarTG","Termine pi&ugrave; generico (BT)");
-define("MENU_AgregarTE","Termine pi&ugrave; specifico (NT)");
+define("MENU_AgregarTE","Termine piú specifico (NT)");
 define("MENU_AgregarTR","Termine associato (RT)");
-define("MENU_AgregarUP","Termine non preferito (UF)");
+define("MENU_AgregarUP","Termine non preferito (UF)");  /* Non-descriptor */
 define("MENU_MisDatos","Il mio accesso");
 define("MENU_Caducar","Disabilita");
 define("MENU_Habilitar","Abilita");
@@ -42,12 +45,12 @@ define("LABEL_editT","Modifica termine");
 define("LABEL_EditorTermino","Editor termini");
 define("LABEL_Termino","Termine");
 define("LABEL_NotaAlcance","Nota");
+define("LABEL_EliminarTE","Cancella termine");
 define("LABEL_AgregarT","Aggiungi termine");
 define("LABEL_AgregarTG","Aggiungi termine pi&ugrave; generico a %s ");
 define("LABEL_AgregarTE","Nuovo termine pi&ugrave; specifico di ");
 define("LABEL_AgregarUP","Nuovo termine non preferito di ");
 define("LABEL_AgregarTR","Collega termine associato a ");
-define("LABEL_EliminarTE","Cancella termine");
 define("LABEL_Detalle","Dettagli");
 define("LABEL_Autor","Autore");
 define("LABEL_URI","URI");
@@ -67,10 +70,10 @@ define("LABEL_Cambiar","Modifica");
 define("LABEL_Anterior","Indietro");
 define("LABEL_AdminUser","Gestione utenti");
 define("LABEL_DatosUser","Dati utenti");
-define("LABEL_Acciones","Attivit&agrave;");
+define("LABEL_Acciones","Attivitá");
 define("LABEL_verEsquema","Mostra schema");
 define("LABEL_actualizar","Aggiorna");
-define("LABEL_terminosLibres","termini liberi");
+define("LABEL_terminosLibres","termini liberi"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Cerca");
 define("LABEL_borraRelacion","Cancella relazione");
 define("MSG_ResultBusca","termini trovati per la ricerca ");
@@ -165,12 +168,10 @@ $MONTHS=array("01"=>"Gen",
 define("LABEL_SI","SI");
 define("LABEL_NO","NO");
 define("FORM_LABEL_jeraquico","poligerarchico");
-define("LABEL_jeraquico","Poligerarchico");
+define("LABEL_jeraquico","Poligerarchico"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","Termine libero");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Cerca %s in: ");
-/* v 9.5 */
-define("USE_termino","USE");
 /* v 9.6 */
 define("LABEL_relacion_vocabulario","Relazione con altro vocabolario");
 define("FORM_LABEL_relacion_vocabulario","equivalenza");
@@ -183,30 +184,22 @@ define("LABEL_tipo_vocabulario","tipo");
 define("LABEL_termino_equivalente","Equivale");
 define("LABEL_termino_parcial_equivalente","Equivale parzialmente");
 define("LABEL_termino_no_equivalente","Non equivale");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota del compilatore");
 define("LABEL_resultados_suplementarios","Risultati supplementari");
 define("LABEL_resultados_relacionados","Risultati associati");
-// define("MENU_NuevoVocabularioReferencia","Nuovo vocabolario di supporto");
 /* v 9.7 */
 define("LABEL_export","esporta");
 define("FORM_LABEL_format_export","seleziona formato");
-define("LABEL_siteMap","Mappa del sito");
-define("LABEL_TotalTopicMap","Thesaurus completo in TopicMaps");
 /* v 1.0 */
 define("LABEL_fecha_creacion","creato il");
-// define("NB_acronimo","BN");
-// define("NH_acronimo","HN");
-// define("NA_acronimo","SN");
-// define("NP_acronimo","PN");
-// define("NC_acronimo","CN");
-define("NB_acronimo","NB");  // nota bibliografica
-define("NH_acronimo","NS");  // nota storica
-define("NA_acronimo","SN");  // nota d'ambito - scope note
-define("NP_acronimo","NP");  // nota privata
-define("NC_acronimo","NC");  // nota compilatore
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NS"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","termine proposto");
 define("LABEL_Aceptado","termine accettato");
 define("LABEL_Rechazado","termine rifiutato");
@@ -217,6 +210,7 @@ define("LABEL_Aceptados","termini accettati");
 define("LABEL_Rechazados","termini rifiutati");
 define("LABEL_User_NoHabilitado","non abilitato");
 define("LABEL_User_Habilitado","abilitato");
+
 define("LABEL_CandidatearTermino","proporre il termine");
 define("LABEL_AceptarTermino","accetta termine");
 define("LABEL_RechazarTermino","rifiuta termine");
@@ -235,6 +229,27 @@ define("MSG_minCharSerarch","L'espressione di ricerca <i>%s</i> ha solo <strong>
 /* v 1.04 */
 define("LABEL_terminoExistente","termine esistente");
 define("HELP_variosTerminos","Per aggiungere termini contemporaneamente incarna <strong>una parola per linea</strong>.");
+/* Install messages */
+define("FORM","Form") ;
+define("ERROR","Error") ;
+define("LABEL_bienvenida","Welcome to TemaTres Vocabulary Server") ;
+// COMMON SQL
+define("PARAM_SERVER","Server address") ;
+define("PARAM_DBName","Database name") ;
+define("PARAM_DBLogin","Database User") ;
+define("PARAM_DBPass","Database Password") ;
+define("PARAM_DBprefix","Prefix tables") ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
+$install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+/* end Install messages */
 /* v 1.1 */
 define('MSG_ERROR_CODE',"codice non valido");
 define('LABEL_CODE',"codice");
@@ -259,7 +274,7 @@ define("IMPORT_do_it","&Egrave; possibile iniziare l'importazione") ;
 define("IMPORT_working","importazione in corso") ;
 define("IMPORT_finish","importazione completata") ;
 define("LABEL_reIndice","ricreare gli indici") ;
-define("LABEL_dbMantenimiento","manutenzione database");
+define("LABEL_dbMantenimiento","manutenzione database");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -277,9 +292,9 @@ define('LABEL_notFound',"termine non trovato");
 define('LABEL_termUpdated',"termine aggiornato");
 define('LABEL_ShowTargetTermforUpdate',"aggiorna");
 define('LABEL_relbetweenVocabularies',"relazione tra vocabolari");
-define('LABEL_update1_1x1_2',"Aggiorna Tematres (1.1 -> 1.3)");
+define('LABEL_update1_1x1_2',"Aggiorna (1.1 -> 1.3)");
 define('LABEL_update1x1_2',"Aggiorna Tematres (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"mapping terminologico)");
+define('LABEL_TargetTerm',"mapping terminologico");
 define('LABEL_TargetTerms',"termini (mapping terminologico)");
 define('LABEL_seleccionar','seleziona');
 define('LABEL_poliBT','pi&ugrave; di un broader term');
@@ -304,7 +319,7 @@ define('IMPORT_skos_form_label','File Skos-Core');
 /*
 v1.4
 */
-define('LABEL_termsxNTterms','Narrower terms x termine');
+define('LABEL_termsxNTterms','Narrower terms x term');
 define('LABEL_termsNoBT','Termini senza relazioni gerarchiche');
 define('MSG_noTermsNoBT','Non ci sono termini senza relazioni gerarchiche');
 define('LABEL_termsXcantWords','numero di parole x termine');
@@ -385,24 +400,24 @@ define('LABEL_user_lost_password',' Password smarrita?');
 ## v1.7
 define('LABEL_includeMetaTerm','Include meta-terms');
 define('NOTE_isMetaTerm','Is a meta-term.');
-define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be use in indexing process. Is a term to describe others terms. Ej: Guide terms, Facets, Categories, etc.');
+define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be used in the indexing process. It is a term to describe others terms. For example: Guide terms, Facets, Categories, etc.');
 define('LABEL_turnOffMetaTerm','Is not a meta-term');
 define('LABEL_turnOnMetaTerm','Is a meta-term');
 define('LABEL_meta_term','meta-term');
 define('LABEL_meta_terms','meta-terms');
 define('LABEL_relatedTerms','related terms');
-define('LABEL_nonPreferedTerms','non preferred terms');
-define('LABEL_update1_6x1_7','Update TemaTres (1.6 -> 2.2)');
+define('LABEL_nonPreferedTerms','termini non preferiti');
+define('LABEL_update1_6x1_7','Update (1.6 -> 2.2)');
 define('LABEL_include_data','include');
 define('LABEL_updateEndpoint','update SPARQL endpoint');
 define('MSG__updateEndpoint','The data will be updated to be exposed in SPARQL endpoint. This operation may take several minutes.');
 define('MSG__updatedEndpoint','The SPARQL endpoint is updated.');
 define('MSG__dateUpdatedEndpoint','Last updated of SPARQL endpoint');
 define('LABEL__ENABLE_SPARQL','You must update the SPARQL endpoint: Menu -> Administration -> Database maintance -> Update SPARQL endpoint.');
-define('MSG__disable_endpoint','The SPARQL endpoint is disable.');
-define('MSG__need2setup_endpoint','The SPARQL endpoint need to be updated. Please contact to the administrator.');
+define('MSG__disable_endpoint','The SPARQL endpoint is disabled.');
+define('MSG__need2setup_endpoint','The SPARQL endpoint needs to be updated. Please contact the administrator.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','Select terms to link as related term with');
+define('LABEL_AgregarRTexist','Select terms to link as related term with ');
 define('MENU_selectExistTerm','select existing term');
 define("TT_terminos","top terms");
 ## v1.72
@@ -410,7 +425,7 @@ define('MSG__warningDeleteTerm','Il termine <i>%s</i> sarà <strong>cancellato</
 define('MSG__warningDeleteTerm2row','Saranno cancellate <strong>tutte</strong> le sue note e le relazioni terminologiche.');
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -419,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -432,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -445,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -466,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -475,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
 define('LABEL_TTTerms','top terms');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -499,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/nl-utf-8.inc.php
+++ b/common/lang/nl-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
 #   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 0.97
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","nl");
-define("TR_acronimo","RT");
-define("TE_acronimo","NT");
-define("TG_acronimo","BT");
-define("UP_acronimo","UF");
+define("TR_acronimo","RT"); /* Related Term */
+define("TE_acronimo","NT"); /* Narrower term > Specific term */
+define("TG_acronimo","BT"); /* Broader term > Generic term */
+define("UP_acronimo","UF"); /* Used for > instead */
 define("TR_termino","Gerelateerde term");
 define("TE_termino","Nauwere term");
 define("TG_termino","Bredere term");
-define("UP_termino","Gebruikt voor");
+define("UP_termino","Gebruikt voor"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","GEBRUIK");
+define("USE_termino","GEBRUIK"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Hiërarchische lijst");
 define("MENU_ListaAbc","Alfabetische lijst");
 define("MENU_Sobre","Over...");
@@ -31,9 +32,9 @@ define("MENU_BorrarT","Verwijder term");
 define("MENU_AgregarTG","Rangschik term onder...");
 define("MENU_AgregarTE","Ondergeschikte term");
 define("MENU_AgregarTR","Gerelateerde term");
-define("MENU_AgregarUP","Niet geprefereerde term");
+define("MENU_AgregarUP","Niet geprefereerde term");  /* Non-descriptor */
 define("MENU_MisDatos","Mijn account");
-define("MENU_Caducar","Deactiveer");
+define("MENU_Caducar","disable");
 define("MENU_Habilitar","Activeer");
 define("MENU_Salir","Uitloggen");
 define("LABEL_Menu","Menu");
@@ -72,8 +73,7 @@ define("LABEL_DatosUser","Gebruikersdata");
 define("LABEL_Acciones","Taken");
 define("LABEL_verEsquema","toon schema");
 define("LABEL_actualizar","Bijwerken");
-define("LABEL_terminosLibres","Vrije termen");
-define("LABEL_TotalTerminos","Totaal termen");
+define("LABEL_terminosLibres","Vrije termen"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Zoek");
 define("LABEL_borraRelacion","verwijder relatie");
 define("MSG_ResultBusca","term(en) gevonden voor zoekexpressie ");
@@ -141,6 +141,7 @@ define("MSGL_relacionIlegal","Illegale relatie tussen terms");
 /* v 9.3 */
 define("LABEL_fecha_modificacion","gewijzigd");
 define("LABEL_TotalUsuarios","Totaal gebruikers");
+define("LABEL_TotalTerminos","Totaal termen");
 define("LABEL_ordenar","sorteer op");
 define("LABEL_auditoria","termenoverzicht");
 define("LABEL_dia","dag");
@@ -167,7 +168,7 @@ $MONTHS=array("01"=>"jan",
 define("LABEL_SI","JA");
 define("LABEL_NO","NEE");
 define("FORM_LABEL_jeraquico","polihiërarchisch");
-define("LABEL_jeraquico","Polihiërarchisch");
+define("LABEL_jeraquico","Polihiërarchisch"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","vrije term");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Zoek %s in:");
@@ -183,9 +184,9 @@ define("LABEL_tipo_vocabulario","soort");
 define("LABEL_termino_equivalente","equivalent");
 define("LABEL_termino_parcial_equivalente","gedeeltelijk equivalent");
 define("LABEL_termino_no_equivalente","niet equivalent");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Catalogiseerder's notitie");
 define("LABEL_resultados_suplementarios","aanvullende resultaten");
 define("LABEL_resultados_relacionados","gerelateerde resultaten");
@@ -194,11 +195,11 @@ define("LABEL_export","export");
 define("FORM_LABEL_format_export","selecteer XML schema");
 /* v 1.0 */
 define("LABEL_fecha_creacion","gecreeërd");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
 define("LABEL_Candidato","kandidaatterm");
 define("LABEL_Aceptado","geaccepteerde term");
 define("LABEL_Rechazado","verworpen term");
@@ -209,7 +210,7 @@ define("LABEL_Aceptados","geaccepteerde termen");
 define("LABEL_Rechazados","verworpen termen");
 define("LABEL_User_NoHabilitado","niet actief");
 define("LABEL_User_Habilitado","actief");
-// define("LABEL_CandidatearTermino","Candidatear término");
+
 define("LABEL_CandidatearTermino","kandideer term");
 define("LABEL_AceptarTermino","accepteer term");
 define("LABEL_RechazarTermino","verwerp term");
@@ -223,12 +224,33 @@ define("LABEL_Guardar","exporteren");
 define("MENU_AgregarTEexist","Subordinate An Existing Term");
 define("MENU_AgregarUPexist","Associate An Existing Non-Preferred Term");
 define("LABEL_existAgregarUP","Add UF term to %s");
-define("LABEL_existAgregarTE","Add narrow Term to %s ");
+define("LABEL_existAgregarTE","Add narrower term to %s ");
 define("MSG_minCharSerarch","The search expression <i>%s</i> has only <strong>%s </strong> characters. Must be greater than <strong>%s</strong> characters");
 /* v 1.04 */
 define("LABEL_terminoExistente","exist term");
 define("HELP_variosTerminos","To add multiple terms at once please put <strong>one a term per line</strong>.");
- /* v 1.1 */
+/* Install messages */
+define("FORM","Form") ;
+define("ERROR","Error") ;
+define("LABEL_bienvenida","Welcome to TemaTres Vocabulary Server") ;
+// COMMON SQL
+define("PARAM_SERVER","Server address") ;
+define("PARAM_DBName","Database name") ;
+define("PARAM_DBLogin","Database User") ;
+define("PARAM_DBPass","Database Password") ;
+define("PARAM_DBprefix","Prefix tables") ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
+$install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+/* end Install messages */
+/* v 1.1 */
 define('MSG_ERROR_CODE',"invalid code");
 define('LABEL_CODE',"code");
 define('LABEL_Ver',"Show");
@@ -242,17 +264,17 @@ define('LABEL_ProfundidadTermino',"is located in deep level");
 define('LABEL_esNoPreferido',"non preferred term");
 define('LABEL_BusquedaAvanzada',"advanced search");
 define('LABEL_Todos',"all");
-define('LABEL_QueBuscar',"what search?");
+define('LABEL_QueBuscar',"what to search?");
 define("LABEL_import","import") ;
 define("IMPORT_form_legend","import thesaurus from file") ;
 define("IMPORT_form_label","file") ;
 define("IMPORT_file_already_exists","a txt file is already present on the server") ;
 define("IMPORT_file_not_exists","no import txt file yet") ;
 define("IMPORT_do_it","You can start the import") ;
-define("IMPORT_working","import task are working") ;
+define("IMPORT_working","import task is working") ;
 define("IMPORT_finish","import task finished") ;
 define("LABEL_reIndice","recreate indexes") ;
-define("LABEL_dbMantenimiento","maintenance database");
+define("LABEL_dbMantenimiento","database maintenance");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -264,20 +286,20 @@ define('LABEL_tvocab_tag',"tag for the reference");
 define('LABEL_tvocab_uri_service',"URL for the web services reference");
 define('LABEL_targetTermsforUpdate',"terms with pending update");
 define('LABEL_ShowTargetTermsforUpdate',"check terms update");
-define('LABEL_enable',"enable");
+define('LABEL_enable',"actief");
 define('LABEL_disable',"disable");
 define('LABEL_notFound',"term not found");
 define('LABEL_termUpdated',"term updated");
 define('LABEL_ShowTargetTermforUpdate',"update");
 define('LABEL_relbetweenVocabularies',"relations between vocabularies");
-define('LABEL_update1_1x1_2',"Update Tematres (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"Update Tematres (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"terminological mapping)");
+define('LABEL_update1_1x1_2',"Update (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Update (1.0x -> 1.3)");
+define('LABEL_TargetTerm',"terminological mapping");
 define('LABEL_TargetTerms',"terms (terminological mapping)");
 define('LABEL_seleccionar','select');
 define('LABEL_poliBT','more than one broader term');
-define('LABEL_FORM_simpleReport','reports');
-define('LABEL_FORM_advancedReport','advances reports');
+define('LABEL_FORM_simpleReport','Reports');
+define('LABEL_FORM_advancedReport','advanced reports');
 define('LABEL_FORM_nullValue','no matters');
 define('LABEL_FORM_haveNoteType','have note type');
 define('LABEL_haveEQ','have equivalences');
@@ -309,8 +331,8 @@ define('LABEL_CFG_SIMPLE_WEB_SERVICE','enable web services');
 define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','Number of terms display by status view');
 define('LABEL_CFG_MIN_SEARCH_SIZE','Minimum characters for search operations');
 define('LABEL__SHOW_TREE','publish hierarchical view in home');
-define('LABEL__PUBLISH_SKOS','enable Skos-core format in web services. This could to expose entire your vocabulary.');
-define('LABEL_update1_3x1_4',"Update Tematres (1.3x -> 1.4)");
+define('LABEL__PUBLISH_SKOS','enable SKOS-Core format in web services. This will expose your entire vocabulary.');
+define('LABEL_update1_3x1_4',"Update (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","choose format");
 define("LABEL_importTab","tabulated text");
 define("LABEL_importTag","tagged text");
@@ -327,7 +349,7 @@ define("LABEL_relationDelete","delete relation sub-type");
 define('LABEL_relationSubType',"relation type");
 define('LABEL_relationSubTypeCode',"relation sub-type alias");
 define('LABEL_relationSubTypeLabel',"relation sub-type label");
-define('LABEL_optative',"opcional");
+define('LABEL_optative',"optional");
 define('FORM_JS_confirmDeleteTypeRelation','delete this relation sub-type?');
 define("LABEL_URItypeEditor","link type editor");
 define("LABEL_URIEditor","manage links associated to the term");
@@ -359,7 +381,7 @@ define('LABEL_more','more');
 define('LABEL_less','less');
 define('LABEL_lastChangeDate','last change date');
 define('LABEL_update1_5x1_6','Update (1.5 -> 1.6)');
-define('LABEL_login','acceder');
+define('LABEL_login','login');
 define('LABEL_user_recovery_password','Get new password');
 define('LABEL_user_recovery_password1','Please enter your username or email address. You will receive a link to create a new password via email.');
 define('LABEL_mail_recoveryTitle','Password Reset');
@@ -374,36 +396,36 @@ define('LABEL_mail_pass3','You can change it.');
 define('MSG_check_mail_link','Check your e-mail for the confirmation link.');
 define('MSG_check_mail','Please check your e-mail.');
 define('MSG_no_mail','The e-mail could not be sent.');
-define('LABEL_user_lost_password',' Lost your password?');
+define('LABEL_user_lost_password','Lost your password?');
 ## v1.7
 define('LABEL_includeMetaTerm','Include meta-terms');
 define('NOTE_isMetaTerm','Is a meta-term.');
-define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be use in indexing process. Is a term to describe others terms. Ej: Guide terms, Facets, Categories, etc.');
+define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be used in the indexing process. It is a term to describe others terms. For example: Guide terms, Facets, Categories, etc.');
 define('LABEL_turnOffMetaTerm','Is not a meta-term');
 define('LABEL_turnOnMetaTerm','Is a meta-term');
 define('LABEL_meta_term','meta-term');
 define('LABEL_meta_terms','meta-terms');
 define('LABEL_relatedTerms','related terms');
-define('LABEL_nonPreferedTerms','non preferred terms');
-define('LABEL_update1_6x1_7','Update TemaTres (1.6 -> 2.2)');
+define('LABEL_nonPreferedTerms','niet geprefereerde termen');
+define('LABEL_update1_6x1_7','Update (1.6 -> 2.2)');
 define('LABEL_include_data','include');
 define('LABEL_updateEndpoint','update SPARQL endpoint');
 define('MSG__updateEndpoint','The data will be updated to be exposed in SPARQL endpoint. This operation may take several minutes.');
 define('MSG__updatedEndpoint','The SPARQL endpoint is updated.');
 define('MSG__dateUpdatedEndpoint','Last updated of SPARQL endpoint');
 define('LABEL__ENABLE_SPARQL','You must update the SPARQL endpoint: Menu -> Administration -> Database maintance -> Update SPARQL endpoint.');
-define('MSG__disable_endpoint','The SPARQL endpoint is disable.');
-define('MSG__need2setup_endpoint','The SPARQL endpoint need to be updated. Please contact to the administrator.');
+define('MSG__disable_endpoint','The SPARQL endpoint is disabled.');
+define('MSG__need2setup_endpoint','The SPARQL endpoint needs to be updated. Please contact the administrator.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','Select terms to link as related term with');
+define('LABEL_AgregarRTexist','Select terms to link as related term with ');
 define('MENU_selectExistTerm','select existing term');
 define("TT_terminos","top terms");
 ## v1.72
 define('MSG__warningDeleteTerm','The term <i>%s</i> will be <strong>DELETED</strong>.');
-define('MSG__warningDeleteTerm2row','Will be deleted <strong>all</strong> his notes and relations. These action are irreversible!');
+define('MSG__warningDeleteTerm2row','Will delete <strong>all</strong> the term\'s notes and relations. These actions are irreversible!');
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -412,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -425,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -438,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -459,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -468,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
 define('LABEL_TTTerms','top terms');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -492,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/pl-utf-8.inc.php
+++ b/common/lang/pl-utf-8.inc.php
@@ -1,22 +1,23 @@
 <?php
 #   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 0.97
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
 #
 define("LANG","pl");
-define("TR_acronimo","RT");
-define("TE_acronimo","NT");
-define("TG_acronimo","BT");
-define("UP_acronimo","UF");
+define("TR_acronimo","RT"); /* Related Term */
+define("TE_acronimo","NT"); /* Narrower term > Specific term */
+define("TG_acronimo","BT"); /* Broader term > Generic term */
+define("UP_acronimo","UF"); /* Used for > instead */
 define("TR_termino","Termin powiązany");
 define("TE_termino","Termin węższy");
 define("TG_termino","Termin szerszy");
-define("UP_termino","Używany dla");
+define("UP_termino","Używany dla"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","Użyj");
+define("USE_termino","Użyj"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Lista hierarchiczna");
 define("MENU_ListaAbc","Lista alfabetyczna");
 define("MENU_Sobre","O ...");
@@ -31,7 +32,7 @@ define("MENU_BorrarT","Usuń termin");
 define("MENU_AgregarTG","Podporządkuj ten termin");
 define("MENU_AgregarTE","Subordinated Term");
 define("MENU_AgregarTR","Termin powiązany");
-define("MENU_AgregarUP","Termin równoznaczny");
+define("MENU_AgregarUP","Termin równoznaczny");  /* Non-descriptor */
 define("MENU_MisDatos","Moje konto");
 define("MENU_Caducar","Deaktywuj");
 define("MENU_Habilitar","Dostępne");
@@ -72,7 +73,7 @@ define("LABEL_DatosUser","Dane użytkownika");
 define("LABEL_Acciones","Zadania");
 define("LABEL_verEsquema","Pokaż schemat");
 define("LABEL_actualizar","Aktualizuj");
-define("LABEL_terminosLibres","Wolne terminy");
+define("LABEL_terminosLibres","Wolne terminy"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Szukaj");
 define("LABEL_borraRelacion","Usuń relację");
 define("MSG_ResultBusca","Znaleziono termin/ów ");
@@ -167,12 +168,12 @@ $MONTHS=array("01"=>"Sty",
 define("LABEL_SI","TAK");
 define("LABEL_NO","NIE");
 define("FORM_LABEL_jeraquico","polihierarchiczny");
-define("LABEL_jeraquico","Polihierarchiczny");
+define("LABEL_jeraquico","Polihierarchiczny"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","wolny termin");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Znajdź %s w:");
 /* v 9.6 */
-define("LABEL_relacion_vocabulario","relación con otro vocabulario");
+define("LABEL_relacion_vocabulario","relationship with another vocabulary");
 define("FORM_LABEL_relacion_vocabulario","równowartość");
 define("FORM_LABEL_nombre_vocabulario","docelowe słownictwo");
 define("LABEL_vocabulario_referencia","docelowe słownictwo");
@@ -183,9 +184,9 @@ define("LABEL_tipo_vocabulario","typ");
 define("LABEL_termino_equivalente","równoważny");
 define("LABEL_termino_parcial_equivalente","częściowo równoważny");
 define("LABEL_termino_no_equivalente","nie równoważny");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Cataloger's note");
 define("LABEL_resultados_suplementarios","dodatkowe wyniki");
 define("LABEL_resultados_relacionados","powiązane wyniki");
@@ -194,11 +195,11 @@ define("LABEL_export","eksport");
 define("FORM_LABEL_format_export","wybierz schemat XML");
 /* v 1.0 */
 define("LABEL_fecha_creacion","utworzony");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
 define("LABEL_Candidato","proponowany termin");
 define("LABEL_Aceptado","zatwierdzony termin");
 define("LABEL_Rechazado","odrzucony termin");
@@ -209,7 +210,7 @@ define("LABEL_Aceptados","zatwierdzone terminy");
 define("LABEL_Rechazados","odrzucone terminy");
 define("LABEL_User_NoHabilitado","wyłącz");
 define("LABEL_User_Habilitado","włącz");
-// define("LABEL_CandidatearTermino","Candidatear término");
+
 define("LABEL_CandidatearTermino","proponowany termin");
 define("LABEL_AceptarTermino","zatwierdź termin");
 define("LABEL_RechazarTermino","odrzuć termin");
@@ -238,15 +239,15 @@ define("PARAM_DBName","Nazwa bazy danych") ;
 define("PARAM_DBLogin","Użytkownik bazy danych") ;
 define("PARAM_DBPass","Hasło do bazy danych") ;
 define("PARAM_DBprefix","Prefix dla tabel") ;
-$install_message[101] = "Konfiguracja TemaTres" ;
-$install_message[201] = "Nie mogę odnaleźć pliku z konfiguracją połączenia do bazy danych (%s)." ;
-$install_message[202] = "Znaleziono plik z konfiguracją połączenia do bazy danych." ;
-$install_message[203] = "Nie udało się połączyć z serwerem bazy danych <em>%s</em> jako użytkownik <em>%s</em>. Proszę sprawdzić konfigurację (%s)." ;
-$install_message[204] = "Pomyślnie nawiązano połączenie z serwerem <em>%s</em>" ;
-$install_message[205] = "Nie udało się połączyć do bazy danych <em>%s</em> na serwerze <em>%s</em>. Proszę sprawdzić konfigurację (%s)." ;
-$install_message[206] = "Pomyślnie nawiązano połączenie z bazą danych <em>%s</em> na serwerze <em>%s</em>." ;
-$install_message[301] = 'Woppsss... There is already an Tematres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
-$install_message[305] = " Sprawdzanie hasła." ;
+$install_message[101] = 'Konfiguracja TemaTres' ;
+$install_message[201] = 'Nie mogę odnaleźć pliku z konfiguracją połączenia do bazy danych (%s).';
+$install_message[202] = 'Znaleziono plik z konfiguracją połączenia do bazy danych.';
+$install_message[203] = 'Nie udało się połączyć z serwerem bazy danych <em>%s</em> jako użytkownik <em>%s</em>. Proszę sprawdzić konfigurację (%s).';
+$install_message[204] = 'Pomyślnie nawiązano połączenie z serwerem <em>%s</em>';
+$install_message[205] = 'Nie udało się połączyć do bazy danych <em>%s</em> na serwerze <em>%s</em>. Proszę sprawdzić konfigurację (%s).';
+$install_message[206] = 'Pomyślnie nawiązano połączenie z bazą danych <em>%s</em> na serwerze <em>%s</em>.' ;
+$install_message[301] = 'Ooppsss... Dla tej konfiguracji istnieje już instalacja TemaTres. Proszę sprawdzić konfigurację z bazą danych (%s) złoto <a href="index.php">Ciesz się swoim serwerem Vocabulary</a>' ;
+$install_message[305] = ' Sprawdzanie hasła.' ;
 $install_message[306] = 'Konfiguracja zakończona pomyślnie, <a href="index.php">Miłego korzystania z Serwera TemaTres</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -265,7 +266,7 @@ define('LABEL_BusquedaAvanzada',"wyszukiwanie zaawansowane");
 define('LABEL_Todos',"wszystko");
 define('LABEL_QueBuscar',"jakie wyszukiwanie?");
 define("LABEL_import","importowanie") ;
-define("IMPORT_form_legend","importuj tezaurus z pliku txt wciętego tabulatorami") ;
+define("IMPORT_form_legend","importuj tezaurus z pliku txt") ;
 define("IMPORT_form_label","plik") ;
 define("IMPORT_file_already_exists","plik txt już istnieje na serwerze") ;
 define("IMPORT_file_not_exists","jeszcze nie zaimportowano pliku txt") ;
@@ -273,7 +274,7 @@ define("IMPORT_do_it","Można rozpocząć importowanie") ;
 define("IMPORT_working","trwa importowanie") ;
 define("IMPORT_finish","importowanie zakończone") ;
 define("LABEL_reIndice","odtwórz indeksy") ;
-define("LABEL_dbMantenimiento","utrzymywanie bazy danych");
+define("LABEL_dbMantenimiento","utrzymywanie bazy danych");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -285,20 +286,20 @@ define('LABEL_tvocab_tag',"tag for the reference");
 define('LABEL_tvocab_uri_service',"URL for the web services reference");
 define('LABEL_targetTermsforUpdate',"terms with pending update");
 define('LABEL_ShowTargetTermsforUpdate',"check terms update");
-define('LABEL_enable',"enable");
-define('LABEL_disable',"disable");
+define('LABEL_enable',"włącz");
+define('LABEL_disable',"Deaktywuj");
 define('LABEL_notFound',"term not found");
 define('LABEL_termUpdated',"term updated");
 define('LABEL_ShowTargetTermforUpdate',"update");
 define('LABEL_relbetweenVocabularies',"relations between vocabularies");
-define('LABEL_update1_1x1_2',"Update Tematres (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"Update Tematres (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"terminological mapping)");
+define('LABEL_update1_1x1_2',"Update (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Update (1.0x -> 1.3)");
+define('LABEL_TargetTerm',"terminological mapping");
 define('LABEL_TargetTerms',"terms (terminological mapping)");
 define('LABEL_seleccionar','select');
 define('LABEL_poliBT','more than one broader term');
-define('LABEL_FORM_simpleReport','reports');
-define('LABEL_FORM_advancedReport','advances reports');
+define('LABEL_FORM_simpleReport','Reports');
+define('LABEL_FORM_advancedReport','advanced reports');
 define('LABEL_FORM_nullValue','no matters');
 define('LABEL_FORM_haveNoteType','have note type');
 define('LABEL_haveEQ','have equivalences');
@@ -330,8 +331,8 @@ define('LABEL_CFG_SIMPLE_WEB_SERVICE','enable web services');
 define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','Number of terms display by status view');
 define('LABEL_CFG_MIN_SEARCH_SIZE','Minimum characters for search operations');
 define('LABEL__SHOW_TREE','publish hierarchical view in home');
-define('LABEL__PUBLISH_SKOS','enable Skos-core format in web services. This could to expose entire your vocabulary.');
-define('LABEL_update1_3x1_4',"Update Tematres (1.3x -> 1.4)");
+define('LABEL__PUBLISH_SKOS','enable SKOS-Core format in web services. This will expose your entire vocabulary.');
+define('LABEL_update1_3x1_4',"Update (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","choose format");
 define("LABEL_importTab","tabulated text");
 define("LABEL_importTag","tagged text");
@@ -348,7 +349,7 @@ define("LABEL_relationDelete","delete relation sub-type");
 define('LABEL_relationSubType',"relation type");
 define('LABEL_relationSubTypeCode',"relation sub-type alias");
 define('LABEL_relationSubTypeLabel',"relation sub-type label");
-define('LABEL_optative',"opcional");
+define('LABEL_optative',"optional");
 define('FORM_JS_confirmDeleteTypeRelation','delete this relation sub-type?');
 define("LABEL_URItypeEditor","link type editor");
 define("LABEL_URIEditor","manage links associated to the term");
@@ -380,7 +381,7 @@ define('LABEL_more','more');
 define('LABEL_less','less');
 define('LABEL_lastChangeDate','last change date');
 define('LABEL_update1_5x1_6','Update (1.5 -> 1.6)');
-define('LABEL_login','acceder');
+define('LABEL_login','login');
 define('LABEL_user_recovery_password','Get new password');
 define('LABEL_user_recovery_password1','Please enter your username or email address. You will receive a link to create a new password via email.');
 define('LABEL_mail_recoveryTitle','Password Reset');
@@ -395,36 +396,36 @@ define('LABEL_mail_pass3','You can change it.');
 define('MSG_check_mail_link','Check your e-mail for the confirmation link.');
 define('MSG_check_mail','Please check your e-mail.');
 define('MSG_no_mail','The e-mail could not be sent.');
-define('LABEL_user_lost_password',' Lost your password?');
+define('LABEL_user_lost_password','Lost your password?');
 ## v1.7
 define('LABEL_includeMetaTerm','Include meta-terms');
 define('NOTE_isMetaTerm','Is a meta-term.');
-define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be use in indexing process. Is a term to describe others terms. Ej: Guide terms, Facets, Categories, etc.');
+define('NOTE_isMetaTermNote','A Meta-term is a term that can\'t be used in the indexing process. It is a term to describe others terms. For example: Guide terms, Facets, Categories, etc.');
 define('LABEL_turnOffMetaTerm','Is not a meta-term');
 define('LABEL_turnOnMetaTerm','Is a meta-term');
 define('LABEL_meta_term','meta-term');
 define('LABEL_meta_terms','meta-terms');
 define('LABEL_relatedTerms','related terms');
-define('LABEL_nonPreferedTerms','non preferred terms');
-define('LABEL_update1_6x1_7','Update TemaTres (1.6 -> 2.2)');
+define('LABEL_nonPreferedTerms','terminy równoznaczne');
+define('LABEL_update1_6x1_7','Update (1.6 -> 2.2)');
 define('LABEL_include_data','include');
 define('LABEL_updateEndpoint','update SPARQL endpoint');
 define('MSG__updateEndpoint','The data will be updated to be exposed in SPARQL endpoint. This operation may take several minutes.');
 define('MSG__updatedEndpoint','The SPARQL endpoint is updated.');
 define('MSG__dateUpdatedEndpoint','Last updated of SPARQL endpoint');
 define('LABEL__ENABLE_SPARQL','You must update the SPARQL endpoint: Menu -> Administration -> Database maintance -> Update SPARQL endpoint.');
-define('MSG__disable_endpoint','The SPARQL endpoint is disable.');
-define('MSG__need2setup_endpoint','The SPARQL endpoint need to be updated. Please contact to the administrator.');
+define('MSG__disable_endpoint','The SPARQL endpoint is disabled.');
+define('MSG__need2setup_endpoint','The SPARQL endpoint needs to be updated. Please contact the administrator.');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','Select terms to link as related term with');
+define('LABEL_AgregarRTexist','Select terms to link as related term with ');
 define('MENU_selectExistTerm','select existing term');
 define("TT_terminos","top terms");
 ## v1.72
 define('MSG__warningDeleteTerm','The term <i>%s</i> will be <strong>DELETED</strong>.');
-define('MSG__warningDeleteTerm2row','Will be deleted <strong>all</strong> his notes and relations. These action are irreversible!');
+define('MSG__warningDeleteTerm2row','Will delete <strong>all</strong> the term\'s notes and relations. These actions are irreversible!');
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -433,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -446,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -459,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -480,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -489,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
 define('LABEL_TTTerms','top terms');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -513,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/pt-BR-utf-8.inc.php
+++ b/common/lang/pt-BR-utf-8.inc.php
@@ -1,21 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
-#   Author for this i18n: Tiago Murakami - trmurakami @ gmail.com
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 1.7
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
-define("LANG","pt");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+#
+define("LANG","pt-BR");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Termo relacionado");
 define("TE_termino","Termo específico");
 define("TG_termino","Termo geral");
-define("UP_termino","Usado para");
+define("UP_termino","Usado para"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USE");
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Lista sistemática");
 define("MENU_ListaAbc","Lista alfabética");
 define("MENU_Sobre","Sobre...");
@@ -30,7 +32,7 @@ define("MENU_BorrarT","Apagar termo");
 define("MENU_AgregarTG","Subordinar a um termo");
 define("MENU_AgregarTE","Termo subordinado");
 define("MENU_AgregarTR","Termo relacionado");
-define("MENU_AgregarUP","Termo não preferido");
+define("MENU_AgregarUP","Termo não preferido");  /* Non-descriptor */
 define("MENU_MisDatos","Minha conta");
 define("MENU_Caducar","Desabilitar");
 define("MENU_Habilitar","Habilitar");
@@ -43,14 +45,13 @@ define("LABEL_editT","Editar termo ");
 define("LABEL_EditorTermino","Editor de termo");
 define("LABEL_Termino","Termo");
 define("LABEL_NotaAlcance","Nota de escopo");
+define("LABEL_EliminarTE","Excluir termo");
 define("LABEL_AgregarT","Novo termo subordinado");
 define("LABEL_AgregarTG","Subordinar %s a um termo superior");
 define("LABEL_AgregarTE","Novo termo subordinado a ");
 define("LABEL_AgregarUP","Novo termo não preferido para ");
 define("LABEL_AgregarTR","Novo termo relacionado com ");
-define("LABEL_EliminarTE","Excluir termo");
 define("LABEL_Detalle","detalhes");
-define("LABEL_EditarNota","editar nota");
 define("LABEL_Autor","Autor");
 define("LABEL_URI","URI");
 define("LABEL_Version","Criado por");
@@ -72,7 +73,7 @@ define("LABEL_DatosUser","Dados do usuário");
 define("LABEL_Acciones","Tarefas");
 define("LABEL_verEsquema","Mostrar esquema");
 define("LABEL_actualizar","Atualizar");
-define("LABEL_terminosLibres","Termos livres");
+define("LABEL_terminosLibres","Termos livres"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Busca");
 define("LABEL_borraRelacion","eliminar relação");
 define("MSG_ResultBusca","termo/s encontrados na busca");
@@ -119,14 +120,15 @@ define("LABEL_verDetalle","mostrar detalhes de ");
 define("LABEL_verTerminosLetra","mostrar termos iniciados com ");
 define("LABEL_NB","Nota bibliográfica");
 define("LABEL_NH","Nota histórica");
-define("LABEL_NA","Nota de escopo"); /* version 0.9.1 */
-define("LABEL_NP","Nota privada");   /* version 0.9.1 */
+define("LABEL_NA","Nota de escopo");   /* version 0.9.1 */
+define("LABEL_NP","Nota privada"); /* version 0.9.1 */
 define("LABEL_EditorNota","Editor de notas");
 define("LABEL_EditorNotaTermino","Notas do termo ");
 define("LABEL_tipoNota","tipo de nota");
 define("FORM_LABEL_tipoNota","tipo_nota");
 define("LABEL_nota","nota");
 define("FORM_LABEL_nota","_nota");
+define("LABEL_EditarNota","editar nota");
 define("LABEL_EliminarNota","Excluir nota");
 define("LABEL_OptimizarTablas","Otimizar tabelas");
 define("LABEL_TotalZthesLine","Tesauro completo em Zthes");
@@ -160,13 +162,13 @@ $MONTHS=array("01"=>"Jan",
               "09"=>"Set",
               "10"=>"Out",
               "11"=>"Nov",
-              "12"=>"Dez",
+              "12"=>"Dez"
               );
 /* v 9.4 */
 define("LABEL_SI","SIM");
 define("LABEL_NO","NÃO");
 define("FORM_LABEL_jeraquico","hierárquico");
-define("LABEL_jeraquico","Poli-hierárquico");
+define("LABEL_jeraquico","Poli-hierárquico"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","termo livre");
 /* v 9.5 */
 define("LABEL_URL_busqueda","Buscar %s em: ");
@@ -182,9 +184,9 @@ define("LABEL_tipo_vocabulario","tipo");
 define("LABEL_termino_equivalente","equivalente");
 define("LABEL_termino_parcial_equivalente","parcialmente equivalente");
 define("LABEL_termino_no_equivalente","não equivalente");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota do catalogador");
 define("LABEL_resultados_suplementarios","resultados suplementares");
 define("LABEL_resultados_relacionados","resultados relacionados");
@@ -193,11 +195,11 @@ define("LABEL_export","exportação");
 define("FORM_LABEL_format_export","selecione esquema XML");
 /* v 1.0 */
 define("LABEL_fecha_creacion","criado");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
 define("LABEL_Candidato","termo candidato");
 define("LABEL_Aceptado","termo aceito");
 define("LABEL_Rechazado","termo não aceito");
@@ -208,7 +210,7 @@ define("LABEL_Aceptados","termos aceitos");
 define("LABEL_Rechazados","termos não aceitos");
 define("LABEL_User_NoHabilitado","não habilitado");
 define("LABEL_User_Habilitado","habilitado");
-// define("LABEL_CandidatearTermino","Candidatear término");
+
 define("LABEL_CandidatearTermino","Passar a termo candidato");
 define("LABEL_AceptarTermino","Aceitar termo");
 define("LABEL_RechazarTermino","Não aceitar termo");
@@ -237,15 +239,15 @@ define("PARAM_DBName","Nome da base de dados") ;
 define("PARAM_DBLogin","Usuário da base de dados") ;
 define("PARAM_DBPass","Senha da base de dados") ;
 define("PARAM_DBprefix","Prefixo das tabelas") ;
-$install_message[101] = "Configuração do TemaTres" ;
-$install_message[201] = "Não foi possível encontrar um arquivo de configuração para a conexão com a base de dados (%s)." ;
-$install_message[202] = "Arquivo de configuração para a base de dados encontrado." ;
-$install_message[203] = "Não foi possível conectar com o servidor da base de dados <em>%s</em> com o usuário <em>%s</em>. Confira seu arquivo de configuração para a conexão da base de dados (%s)." ;
-$install_message[204] = "Sucesso na conexão do servidor <em>%s</em>" ;
-$install_message[205] = "Não foi possível conectar no base de dados <em>%s</em> no servidor <em>%s</em>. Confira seu arquivo de configuração de conexão com a base de dados (%s)." ;
-$install_message[206] = "Sucesso ao conectar na base de dados <em>%s</em> no servidor <em>%s</em>." ;
-$install_message[301] = 'Opa... Já existe uma instancia do Tematres para esta configuração. Confira o arquivo de cofiguração da base de dados (%s). <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = " Conferindo a segurança da senha." ;
+$install_message[101] = 'Configuração do TemaTres' ;
+$install_message[201] = 'Não foi possível encontrar um arquivo de configuração para a conexão com a base de dados (%s).';
+$install_message[202] = 'Arquivo de configuração para a base de dados encontrado.';
+$install_message[203] = 'Não foi possível conectar com o servidor da base de dados <em>%s</em> com o usuário <em>%s</em>. Confira seu arquivo de configuração para a conexão da base de dados (%s).';
+$install_message[204] = 'Sucesso na conexão do servidor <em>%s</em>';
+$install_message[205] = 'Não foi possível conectar no base de dados <em>%s</em> no servidor <em>%s</em>. Confira seu arquivo de configuração de conexão com a base de dados (%s).';
+$install_message[206] = 'Sucesso ao conectar na base de dados <em>%s</em> no servidor <em>%s</em>.' ;
+$install_message[301] = 'Opa... Já existe uma instancia do Tematres para esta configuração. Confira o seu arquivo de configuração para a ligação à base de dados (%s) ou <a href="index.php">Comece a utilizar seu vocabulário</a>' ;
+$install_message[305] = ' Conferindo a segurança da senha.' ;
 $install_message[306] = 'Configuração completa, <a href="index.php">Aproveite seu servidor de vocabulário</a>' ;
 /* end Install messages */
 /* v 1.1 */
@@ -264,7 +266,7 @@ define('LABEL_BusquedaAvanzada',"pesquisa avançada");
 define('LABEL_Todos',"todos");
 define('LABEL_QueBuscar',"o que buscar?");
 define("LABEL_import","importar") ;
-define("IMPORT_form_legend","importar tesauro de um arquivo txt tabulado") ;
+define("IMPORT_form_legend","importar tesauro de um arquivo txt") ;
 define("IMPORT_form_label","arquivo") ;
 define("IMPORT_file_already_exists","um arquivo txt já existe no servidor") ;
 define("IMPORT_file_not_exists","não importar o arquivo txt agora") ;
@@ -272,7 +274,7 @@ define("IMPORT_do_it","Você pode iniciar a importação") ;
 define("IMPORT_working","rodando tarefa de importação") ;
 define("IMPORT_finish","tarefa de importação concluída") ;
 define("LABEL_reIndice","recriar índices") ;
-define("LABEL_dbMantenimiento","Manutenção da base de dados");
+define("LABEL_dbMantenimiento","Manutenção da base de dados");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
@@ -290,7 +292,7 @@ define('LABEL_notFound',"termo não encontrado");
 define('LABEL_termUpdated',"termo atualizado");
 define('LABEL_ShowTargetTermforUpdate',"atualizar");
 define('LABEL_relbetweenVocabularies',"relações entre vocabulários");
-define('LABEL_update1_1x1_2',"Atualizar Tematres (1.1 -> 1.3)");
+define('LABEL_update1_1x1_2',"Atualizar (1.1 -> 1.3)");
 define('LABEL_update1x1_2',"A Tematres (1.0x -> 1.3)");
 define('LABEL_TargetTerm',"termo externo (mapeamento terminológico)");
 define('LABEL_TargetTerms',"termos externos (mapeamento terminológico)");
@@ -299,7 +301,7 @@ define('LABEL_poliBT','mais de um termo geral');
 define('LABEL_FORM_simpleReport','Relatórios');
 define('LABEL_FORM_advancedReport','relatórios avançados');
 define('LABEL_FORM_nullValue','não importa');
-define('LABEL_FORM_haveNoteType','tem nota do tipo');
+define('LABEL_FORM_haveNoteType','tem nota de tipo');
 define('LABEL_haveEQ','tem equivalências');
 define('LABEL_nohaveEQ','sem equivalências');
 define('LABEL_start','que começam com');
@@ -415,11 +417,11 @@ define('LABEL__ENABLE_SPARQL','Deverá atualizar o ponto de consulta: Menu Admin
 define('MSG__disable_endpoint','O ponto de consulta SPARQL está desabilitado.');
 define('MSG__need2setup_endpoint','O ponto de consulta SPARQL precisa ser atualizado. Contate o administrador do sistema');
 define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','associar a um termo existente');
+define('LABEL_AgregarRTexist','Associar um termo associado existente com ');
 define('MENU_selectExistTerm','selecione termo existente');
 define("TT_terminos","Termos superiores");
 ## v1.72
-define('MSG__warningDeleteTerm','O termo <i>%s</i> será <strong>ELIMINADO</strong>.');
+define('MSG__warningDeleteTerm','O termo <i>%s</i> será <strong>EXCLUÍDO</strong>.');
 define('MSG__warningDeleteTerm2row','Serão eliminadas <strong>todas</strong> as notas e relações terminológicas. Esta ação é IRREVERSÍVEL.');
 ## v1.8
 define('LABEL__getForRecomendation','buscar recomendações');
@@ -448,9 +450,9 @@ define('LABEL_defaultEQmap','Utilize "eq" para indicar relação de equivalênci
 define("MSG_repass_error","as chaves não coincidem");
 define("MSG_lengh_error","mínimo de %d caracteres");
 define("MSG_errorPostData","Ocorreu um erro, por favor revise os dados do campo ");
-define('LABEL_preferedTerms','termos preferidos');
+define('LABEL_preferedTerms','termos preferidos');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','termos SEM notas');
-define('MSG_FORM_NULLnotesTermReport','termos sem notas do tipo');
+define('MSG_FORM_NULLnotesTermReport','termos sem notas de tipo');
 define('LABELnoNotes','termos sem nenhuma nota');
 define('LABEL_termsXdeepLevel','termos por nível hierárquico');
 define('LABEL_deepLevel','nível');
@@ -458,7 +460,7 @@ define('LABEL_cantTerms','# de termos');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="Lista de vocabularios controlados conhecidos" target="_blank">Lista de vocabulários controlados conhecidos</a>');
 define('LABEL_showNewsTerm','ver alterações recentes');
 define('LABEL_newsTerm','alterações recentes');
-define('MSG_contactAdmin','contace o administador');
+define('MSG_contactAdmin','contacte o administador');
 define('LABEL_addTargetVocabulary','adicionar vocabulários de referência (serviços web terminológicos)');
 #v.2.1
 define('LABEL_duplicatedTerm','termo duplicado');
@@ -494,11 +496,19 @@ define('LABEL_TTTerms','termos de topo');
 define('MSG__GLOSSincludeAltLabel','incluir termos alternativos');
 define('MSG__GLOSSdocumentationJSON','A fonte JSON do glossário pode ser integrada com qualquer conteúdo HTML por meio da biblioteca <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','exportar fonte de dados para glossário');
-define('MSG_includeNotes','utilizar notas do tipo:');
-define('LABEL_SHOW_RANDOM_TERM','exibir um termo aleatório na página inicial. É necessário escolher um tipo de nota.');
-define('LABEL_opt_show_rando_term','exibir termos com nota tipo:');
+define('MSG_includeNotes','utilizar notas de tipo:');
+define('LABEL_SHOW_RANDOM_TERM','Apresentar na página inicial um termo selecionado randomicamente. Deve ser selecionado um tipo de nota.');
+define('LABEL_opt_show_rando_term','exibir termos com nota de tipo:');
 define('MSG_helpNoteEditor','Associe termos utilizando colchetes duplos. Ex: Só o [[amor]] salvará o mundo');
-define('LABEL_GLOSS_NOTES','Selecionar tipo de nota para glosar termos marcados com colchetes dobles: [[glossário]]');
+define('LABEL_GLOSS_NOTES','Selecionar tipo de nota para glosar termos marcados com colchetes duplas: [[glossario]]');
+define('LABEL_bulkGlossNotes','tipo de nota a glosar');
+define('MSG__autoGlossInfo','Este proceso associa os termos existentes no vocabulário às suas menções nas notas. É utilizada a notação Wiki (Ex.: Só o [[amor]] salvará o mundo). Corresponde a uma operação de pesquisa e substituição de texto <strong>sensível a maiúsculas</strong>.');
+define('MSG__autoGlossDanger','Esta operação altera os dados de forma IRREVERSÍVEL. Antes de continuar, efetue uma cópia de segurança.');
+define('LABEL_replaceBinary','Sensível a maiúsculas e acentos');
+define('MSG_notesAffected','notas afetadas');
+define('MSG_cantTermsFound','termos encontrados');
+define('MENU_glossConfig','Configurações do glossário'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','criação de glossário automático');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referências');
@@ -512,7 +522,10 @@ define('LABEL_close','fechar');
 define('LABEL_allTerms','todos os termos');
 define('LABEL_allNotes','todas as notas');
 define('LABEL_allRelations','todas as relações entre termos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Tradução pela comunidade para TemaTres.'); /* Do not include emails or personal details */
 
-##?
-define('MENU_glossConfig','Configurações do glossário');
 ?>

--- a/common/lang/pt-PT-utf-8.inc.php
+++ b/common/lang/pt-PT-utf-8.inc.php
@@ -1,104 +1,105 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
-#   Author for this i18n: Tiago Murakami - trmurakami @ gmail.com
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Version 1.7
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
 #
 ###############################################################################################################
-define("LANG","pt");
-define("TR_acronimo","TR");
-define("TE_acronimo","TE");
-define("TG_acronimo","TG");
-define("UP_acronimo","UP");
+#
+define("LANG","pt-PT");
+define("TR_acronimo","TR"); /* Related Term */
+define("TE_acronimo","TE"); /* Narrower term > Specific term */
+define("TG_acronimo","TG"); /* Broader term > Generic term */
+define("UP_acronimo","UP"); /* Used for > instead */
 define("TR_termino","Termo relacionado");
 define("TE_termino","Termo específico");
-define("TG_termino","Termo geral");
-define("UP_termino","Usado para");
+define("TG_termino","Termo genérico");
+define("UP_termino","Usado por"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
 /* v 9.5 */
-define("USE_termino","USE");
+define("USE_termino","USE"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Lista sistemática");
 define("MENU_ListaAbc","Lista alfabética");
 define("MENU_Sobre","Sobre...");
 define("MENU_Inicio","Início");
 define("MENU_MiCuenta","Minha conta");
-define("MENU_Usuarios","Usuários");
-define("MENU_NuevoUsuario","Novo usuário");
+define("MENU_Usuarios","Utilizadores");
+define("MENU_NuevoUsuario","Novo utilizador");
 define("MENU_DatosTesauro","Dados do tesauro");
 define("MENU_AgregarT","Adicionar termo");
 define("MENU_EditT","Editar termo");
-define("MENU_BorrarT","Apagar termo");
-define("MENU_AgregarTG","Subordinar a um termo");
-define("MENU_AgregarTE","Termo subordinado");
-define("MENU_AgregarTR","Termo relacionado");
-define("MENU_AgregarUP","Termo não preferido");
+define("MENU_BorrarT","Eliminar termo");
+define("MENU_AgregarTG","Subordinar a um termo (TG)");
+define("MENU_AgregarTE","Termo subordinado (TE)");
+define("MENU_AgregarTR","Termo relacionado (TR)");
+define("MENU_AgregarUP","Termo não preferencial (UP)");  /* Non-descriptor */
 define("MENU_MisDatos","Minha conta");
-define("MENU_Caducar","Desabilitar");
-define("MENU_Habilitar","Habilitar");
+define("MENU_Caducar","Desativar");
+define("MENU_Habilitar","Ativar");
 define("MENU_Salir","Sair");
 define("LABEL_Menu","Menu");
 define("LABEL_Opciones","Opcões");
 define("LABEL_Admin","Administracão");
 define("LABEL_Agregar","Adicionar");
 define("LABEL_editT","Editar termo ");
-define("LABEL_EditorTermino","Editor de termo");
+define("LABEL_EditorTermino","Editor de termos");
 define("LABEL_Termino","Termo");
-define("LABEL_NotaAlcance","Nota de escopo");
+define("LABEL_NotaAlcance","Nota explicativa");
+define("LABEL_EliminarTE","Eliminar termo");
 define("LABEL_AgregarT","Novo termo subordinado");
-define("LABEL_AgregarTG","Subordinar %s a um termo superior");
-define("LABEL_AgregarTE","Novo termo subordinado a ");
-define("LABEL_AgregarUP","Novo termo não preferido para ");
-define("LABEL_AgregarTR","Novo termo relacionado com ");
-define("LABEL_EliminarTE","Excluir termo");
+define("LABEL_AgregarTG","Subordinar %s ao termo superior ");
+define("LABEL_AgregarTE","Criar termo subordinado a ");
+define("LABEL_AgregarUP","Criar termo não preferencial para ");
+define("LABEL_AgregarTR","Criar termo relacionado com ");
 define("LABEL_Detalle","detalhes");
-define("LABEL_EditarNota","editar nota");
 define("LABEL_Autor","Autor");
 define("LABEL_URI","URI");
-define("LABEL_Version","Criado por");
+define("LABEL_Version","Produzido em");
 define("LABEL_Idioma","Idioma");
 define("LABEL_Fecha","Data de criação");
-define("LABEL_Keywords","Palavras-chaves");
+define("LABEL_Keywords","Palavras-chave");
 define("LABEL_TipoLenguaje","Tipo de linguagem");
-define("LABEL_Cobertura","Cobertura");
+define("LABEL_Cobertura","Âmbito");
 define("LABEL_Terminos","termos");
 define("LABEL_RelTerminos","relacões entre termos");
-define("LABEL_TerminosUP","termos não preferidos");
-define("LABEL_BuscaTermino","Buscar termo");
-define("LABEL_Buscar","Buscar");
+define("LABEL_TerminosUP","termos não preferenciais");
+define("LABEL_BuscaTermino","Pesquisar termo");
+define("LABEL_Buscar","Pesquisar");
 define("LABEL_Enviar","Enviar");
-define("LABEL_Cambiar","Salvar modificações");
-define("LABEL_Anterior","Voltar");
-define("LABEL_AdminUser","Administração de usuários");
-define("LABEL_DatosUser","Dados do usuário");
-define("LABEL_Acciones","Tarefas");
-define("LABEL_verEsquema","Mostrar esquema");
+define("LABEL_Cambiar","Guardar alterações");
+define("LABEL_Anterior","voltar");
+define("LABEL_AdminUser","Administrar utilizadores");
+define("LABEL_DatosUser","Dados do utilizador");
+define("LABEL_Acciones","Ações realizadas");
+define("LABEL_verEsquema","ver esquema");
 define("LABEL_actualizar","Atualizar");
-define("LABEL_terminosLibres","Termos livres");
-define("LABEL_busqueda","Busca");
+define("LABEL_terminosLibres","Termos livres"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
+define("LABEL_busqueda","Pesquisa");
 define("LABEL_borraRelacion","eliminar relação");
-define("MSG_ResultBusca","termo/s encontrados na busca");
+define("MSG_ResultBusca","termos encontrados");
 define("MSG_ResultLetra","Letra");
-define("MSG_ResultCambios","As alterações foram realizadas com sucesso.");
-define("MSG_noUser","Usuário não registrado");
-define("FORM_JS_check","Por favor confira os dados de ");
-define("FORM_JS_confirm","Tem certeza que quer excluir o termo ou a relação?");
-define("FORM_JS_pass","_clave");
+define("MSG_ResultCambios","Alterações realizadas com sucesso.");
+define("MSG_noUser","Utilizador não registrado");
+define("FORM_JS_check","Por favor, verifique os dados de ");
+define("FORM_JS_confirm","Pretende mesmo eliminar o termo ou a relação?");
+define("FORM_JS_pass","_senha");
 define("FORM_JS_confirmPass","_repetir_clave");
 define("FORM_LABEL_termino","_termino");
-define("FORM_LABEL_buscar","_expresion_de_busqueda");
-define("FORM_LABEL_buscarTermino","_termino_relacionado");
-define("FORM_LABEL_nombre","_nombre");
-define("FORM_LABEL_apellido","_apellido");
-define("FORM_LABEL_mail","_correo_electronico");
-define("FORM_LABEL_pass","_clave");
-define("FORM_LABEL_repass","_confirmar_clave");
-define("FORM_LABEL_orga","orga");
+define("FORM_LABEL_buscar","_expressao_de_pesquisa");
+define("FORM_LABEL_buscarTermino","_termo_relacionado");
+define("FORM_LABEL_nombre","_nome");
+define("FORM_LABEL_apellido","_apelido");
+define("FORM_LABEL_mail","_correio_electronico");
+define("FORM_LABEL_pass","_senha");
+define("FORM_LABEL_repass","_confirmar_senha");
+define("FORM_LABEL_orga","organizacao");
 define("LABEL_nombre","nome");
-define("LABEL_apellido","sobrenome");
-define("LABEL_mail","e-mail");
+define("LABEL_apellido","apelido");
+define("LABEL_mail","endereço de email");
 define("LABEL_pass","senha");
 define("LABEL_repass","confirmar senha");
-define("LABEL_orga","organização");
-define("LABEL_lcConfig","Configuração do vocabulário");
+define("LABEL_orga","entidade");
+define("LABEL_lcConfig","Configuração");
 define("LABEL_lcDatos","Dados do vocabulário");
 define("LABEL_Titulo","Título");
 define("FORM_LABEL_Titulo","_titulo");
@@ -108,28 +109,29 @@ define("FORM_LABEL_Idioma","Idioma");
 define("FORM_LABEL_FechaDia","dia");
 define("FORM_LABEL_FechaMes","mês");
 define("FORM_LABEL_FechaAno","ano");
-define("FORM_LABEL_Keywords","Palavras_chave");
-define("FORM_LABEL_TipoLenguaje","language_type");
-define("FORM_LABEL_Cobertura","escopo");
+define("FORM_LABEL_Keywords","palavras_chave");
+define("FORM_LABEL_TipoLenguaje","tipo_idioma");
+define("FORM_LABEL_Cobertura","Âmbito");
 define("FORM_LABEL_Terminos","termos");
 define("FORM_LABEL_RelTerminos","relações entre termos");
-define("FORM_LABEL_TerminosUP","termos não preferidos");
-define("FORM_LABEL_Guardar","Salvar");
-define("LABEL_verDetalle","mostrar detalhes de ");
-define("LABEL_verTerminosLetra","mostrar termos iniciados com ");
+define("FORM_LABEL_TerminosUP","termos não preferenciais");
+define("FORM_LABEL_Guardar","Guardar");
+define("LABEL_verDetalle","ver detalhes de ");
+define("LABEL_verTerminosLetra","mostrar termos começados por ");
 define("LABEL_NB","Nota bibliográfica");
 define("LABEL_NH","Nota histórica");
-define("LABEL_NA","Nota de escopo"); /* version 0.9.1 */
-define("LABEL_NP","Nota privada");   /* version 0.9.1 */
-define("LABEL_EditorNota","Editor de notas");
+define("LABEL_NA","Nota explicativa");   /* version 0.9.1 */
+define("LABEL_NP","Nota privada"); /* version 0.9.1 */
+define("LABEL_EditorNota","Editor de notas ");
 define("LABEL_EditorNotaTermino","Notas do termo ");
 define("LABEL_tipoNota","tipo de nota");
 define("FORM_LABEL_tipoNota","tipo_nota");
 define("LABEL_nota","nota");
 define("FORM_LABEL_nota","_nota");
-define("LABEL_EliminarNota","Excluir nota");
+define("LABEL_EditarNota","editar nota");
+define("LABEL_EliminarNota","Eliminar nota");
 define("LABEL_OptimizarTablas","Otimizar tabelas");
-define("LABEL_TotalZthesLine","Tesauro completo em Zthes");
+define("LABEL_TotalZthesLine","exportar para Zthes");
 /* v 9.2 */
 define("LABEL_negrita","negrito");
 define("LABEL_italica","itálico");
@@ -138,7 +140,7 @@ define("LABEL_textarea","área para notas");
 define("MSGL_relacionIlegal","Relação não permitida entre termos");
 /* v 9.3 */
 define("LABEL_fecha_modificacion","modificacão");
-define("LABEL_TotalUsuarios","total de usuários");
+define("LABEL_TotalUsuarios","total de utilizadores");
 define("LABEL_TotalTerminos","total de termos");
 define("LABEL_ordenar","ordenar por");
 define("LABEL_auditoria","auditoria do termos");
@@ -148,197 +150,197 @@ define("LABEL_ano","ano");
 define("LABEL_terminosRepetidos","termos repetidos");
 define("MSG_noTerminosLibres","não existem termos livres");
 define("MSG_noTerminosRepetidos","não existem termos repetidos");
-define("LABEL_TotalSkosLine","Tesauro completo em Skos-Core");
+define("LABEL_TotalSkosLine","exportar para Skos-Core");
 $MONTHS=array("01"=>"Jan",
               "02"=>"Fev",
               "03"=>"Mar",
               "04"=>"Abr",
-              "05"=>"Mai",
+              "05"=>"Maio",
               "06"=>"Jun",
               "07"=>"Jul",
               "08"=>"Ago",
               "09"=>"Set",
               "10"=>"Out",
               "11"=>"Nov",
-              "12"=>"Dez",
+              "12"=>"Dez"
               );
 /* v 9.4 */
 define("LABEL_SI","SIM");
 define("LABEL_NO","NÃO");
-define("FORM_LABEL_jeraquico","hierárquico");
-define("LABEL_jeraquico","Poli-hierárquico");
+define("FORM_LABEL_jeraquico","Hierarquizado");
+define("LABEL_jeraquico","Poli-hierárquica"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","termo livre");
 /* v 9.5 */
-define("LABEL_URL_busqueda","Buscar %s em: ");
+define("LABEL_URL_busqueda","Procurar por %s em: ");
 /* v 9.6 */
 define("LABEL_relacion_vocabulario","relacão com outro vocabulário");
 define("FORM_LABEL_relacion_vocabulario","equivalência");
 define("FORM_LABEL_nombre_vocabulario","vocabulário de referência");
 define("LABEL_vocabulario_referencia","vocabulário de referência");
-define("LABEL_NO_vocabulario_referencia","não existem vocabulários de referência para se estabelecer uma relação terminológica");
+define("LABEL_NO_vocabulario_referencia","não existem vocabulários de referência para se poder estabelecer uma relação terminológica");
 define("FORM_LABEL_tipo_equivalencia","tipo de equivalência");
 define("LABEL_vocabulario_principal","vocabulário");
 define("LABEL_tipo_vocabulario","tipo");
 define("LABEL_termino_equivalente","equivalente");
 define("LABEL_termino_parcial_equivalente","parcialmente equivalente");
 define("LABEL_termino_no_equivalente","não equivalente");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","PEQ"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Nota do catalogador");
-define("LABEL_resultados_suplementarios","resultados suplementares");
+define("LABEL_resultados_suplementarios","mais resultados");
 define("LABEL_resultados_relacionados","resultados relacionados");
 /* v 9.7 */
-define("LABEL_export","exportação");
-define("FORM_LABEL_format_export","selecione esquema XML");
+define("LABEL_export","exportar");
+define("FORM_LABEL_format_export","selecionar esquema XML");
 /* v 1.0 */
 define("LABEL_fecha_creacion","criado");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","NB"); /* Bibliographic note */
+define("NH_acronimo","NH"); /* Historical note */
+define("NA_acronimo","NE"); /* Scope or Explanatory note */
+define("NP_acronimo","NP"); /* Private note */
+define("NC_acronimo","NC"); /* Cataloger's note */
 define("LABEL_Candidato","termo candidato");
-define("LABEL_Aceptado","termo aceito");
-define("LABEL_Rechazado","termo não aceito");
-define("LABEL_Ultimos_aceptados","termos aceitos");
-define("MSG_ERROR_ESTADO","status não permitido");
+define("LABEL_Aceptado","termo aceite");
+define("LABEL_Rechazado","termo não aceite");
+define("LABEL_Ultimos_aceptados","termos aceites");
+define("MSG_ERROR_ESTADO","estatuto não permitido");
 define("LABEL_Candidatos","termos candidatos");
-define("LABEL_Aceptados","termos aceitos");
-define("LABEL_Rechazados","termos não aceitos");
-define("LABEL_User_NoHabilitado","não habilitado");
-define("LABEL_User_Habilitado","habilitado");
-// define("LABEL_CandidatearTermino","Candidatear término");
-define("LABEL_CandidatearTermino","Passar a termo candidato");
+define("LABEL_Aceptados","termos aceites");
+define("LABEL_Rechazados","termos não aceites");
+define("LABEL_User_NoHabilitado","não ativado");
+define("LABEL_User_Habilitado","ativado");
+
+define("LABEL_CandidatearTermino","Propor como termo candidato");
 define("LABEL_AceptarTermino","Aceitar termo");
-define("LABEL_RechazarTermino","Não aceitar termo");
+define("LABEL_RechazarTermino","Rejeitar termo");
 /* v 1.01 */
-define("LABEL_TERMINO_SUGERIDO","você quis dizer?:");
+define("LABEL_TERMINO_SUGERIDO","tente estes termos alternativos:");
 /* v 1.02 */
-define("LABEL_esSuperUsuario","é administrador");
+define("LABEL_esSuperUsuario","É administrador");
 define("LABEL_Cancelar","cancelar");
-define("LABEL_Guardar","salvar");
+define("LABEL_Guardar","guardar");
 /* v 1.033 */
-define("MENU_AgregarTEexist","Subordinar a um termo existente");
-define("MENU_AgregarUPexist","Associar a um termo existente não preferido");
-define("LABEL_existAgregarUP","Adicionar termo UF para %s");
-define("LABEL_existAgregarTE","Adicionar termo específico para %s ");
-define("MSG_minCharSerarch","A expressão de busca <i>%s</i> tem somente <strong>%s </strong> caracteres. Precisa ser maior que <strong>%s</strong> caracteres");
+define("MENU_AgregarTEexist","Subordinar um termo livre");
+define("MENU_AgregarUPexist","Associar termo não preferencial (livre)");
+define("LABEL_existAgregarUP","Adicionar termo UP (não preferencial) a %s");
+define("LABEL_existAgregarTE","Adicionar termo específico a %s ");
+define("MSG_minCharSerarch","A expressão para pesquisa <i>%s</i> tem apenas <strong>%s</strong> caracteres. Terá de ter mais do que <strong>%s</strong> caracteres");
 /* v 1.04 */
 define("LABEL_terminoExistente","termo existente");
-define("HELP_variosTerminos","Para adicionar vários termos de uma vez, favor informar uma palavra por linha</strong>.");
+define("HELP_variosTerminos","Para adicionar vários termos de uma vez coloque <strong>um termo por linha</strong>.");
 /* Install messages */
 define("FORM","Formulário") ;
 define("ERROR","Erro") ;
-define("LABEL_bienvenida","Bem vindo ao Servidor de Vocabulário TemaTres") ;
+define("LABEL_bienvenida","Bem-vindo ao sistema de vocabulários TemaTres") ;
 // COMMON SQL
 define("PARAM_SERVER","Endereço do servidor") ;
 define("PARAM_DBName","Nome da base de dados") ;
-define("PARAM_DBLogin","Usuário da base de dados") ;
+define("PARAM_DBLogin","Utilizador da base de dados") ;
 define("PARAM_DBPass","Senha da base de dados") ;
 define("PARAM_DBprefix","Prefixo das tabelas") ;
-$install_message[101] = "Configuração do TemaTres" ;
-$install_message[201] = "Não foi possível encontrar um arquivo de configuração para a conexão com a base de dados (%s)." ;
-$install_message[202] = "Arquivo de configuração para a base de dados encontrado." ;
-$install_message[203] = "Não foi possível conectar com o servidor da base de dados <em>%s</em> com o usuário <em>%s</em>. Confira seu arquivo de configuração para a conexão da base de dados (%s)." ;
-$install_message[204] = "Sucesso na conexão do servidor <em>%s</em>" ;
-$install_message[205] = "Não foi possível conectar no base de dados <em>%s</em> no servidor <em>%s</em>. Confira seu arquivo de configuração de conexão com a base de dados (%s)." ;
-$install_message[206] = "Sucesso ao conectar na base de dados <em>%s</em> no servidor <em>%s</em>." ;
-$install_message[301] = 'Opa... Já existe uma instancia do Tematres para esta configuração. Confira o arquivo de cofiguração da base de dados (%s). <a href="index.php">Comience a utilizar su vocabulario</a>' ;
-$install_message[305] = " Conferindo a segurança da senha." ;
-$install_message[306] = 'Configuração completa, <a href="index.php">Aproveite seu servidor de vocabulário</a>' ;
+$install_message[101] = 'Configuração do TemaTres' ;
+$install_message[201] = 'Não foi possível encontrar o ficheiro de configuração para a ligação à base de dados (%s).';
+$install_message[202] = 'Ficheiro de configuração para a base de dados encontrado.';
+$install_message[203] = 'Não foi possível ligar ao servidor da base de dados <em>%s</em> com o utilizador <em>%s</em>. Verifique o seu ficheiro de configuração da ligação à base de dados (%s).';
+$install_message[204] = 'Sucesso na ligação ao servidor <em>%s</em> ';
+$install_message[205] = 'Não foi possível ligar à base de dados <em>%s</em> no servidor <em>%s</em>. Verifique o seu ficheiro de configuração da ligação à base de dados (%s).';
+$install_message[206] = 'Sucesso na ligação à base de dados <em>%s</em> no servidor <em>%s</em>.' ;
+$install_message[301] = 'Ooops... Já existe uma instância do Tematres para esta configuração. Verifique o ficheiro de configuração da ligação à base de dados (%s) ou <a href="index.php">Comece a utilizar o seu vocabulário</a>' ;
+$install_message[305] = 'A verificar segurança da senha.' ;
+$install_message[306] = 'Configuração comcluída, <a href="index.php">comece a utilizar o seu vocabulário</a>' ;
 /* end Install messages */
 /* v 1.1 */
 define('MSG_ERROR_CODE',"código inválido");
 define('LABEL_CODE',"código");
-define('LABEL_Ver',"Exibir");
+define('LABEL_Ver',"mostrar");
 define('LABEL_OpcionesTermino',"termo");
-define('LABEL_CambiarEstado',"Alterar status do termo");
+define('LABEL_CambiarEstado',"Alterar estatuto");
 define('LABEL_ClickEditar',"Clique para editar...");
-define('LABEL_TopTerm',"Tem este termo superior");
+define('LABEL_TopTerm',"Tem este termo de topo");
 define('LABEL_esFraseExacta',"frase exata");
 define('LABEL_DesdeFecha',"criado em ou após");
-define('LABEL_ProfundidadTermino',"está localizado no nível mais profundo");
-define('LABEL_esNoPreferido',"termo não preferido");
+define('LABEL_ProfundidadTermino',"localizado num nível profundo");
+define('LABEL_esNoPreferido',"termo não preferencial");
 define('LABEL_BusquedaAvanzada',"pesquisa avançada");
 define('LABEL_Todos',"todos");
-define('LABEL_QueBuscar',"o que buscar?");
+define('LABEL_QueBuscar',"O que pesquisar?");
 define("LABEL_import","importar") ;
-define("IMPORT_form_legend","importar tesauro de um arquivo txt tabulado") ;
-define("IMPORT_form_label","arquivo") ;
-define("IMPORT_file_already_exists","um arquivo txt já existe no servidor") ;
-define("IMPORT_file_not_exists","não importar o arquivo txt agora") ;
-define("IMPORT_do_it","Você pode iniciar a importação") ;
-define("IMPORT_working","rodando tarefa de importação") ;
-define("IMPORT_finish","tarefa de importação concluída") ;
+define("IMPORT_form_legend","importar tesauro de um ficheiro") ;
+define("IMPORT_form_label","ficheiro") ;
+define("IMPORT_file_already_exists","já existe um ficheiro txt no servidor") ;
+define("IMPORT_file_not_exists","não importar o ficheiro txt agora") ;
+define("IMPORT_do_it","Pode iniciar a importação") ;
+define("IMPORT_working","processo de importação em execução") ;
+define("IMPORT_finish","processo de importação concluída") ;
 define("LABEL_reIndice","recriar índices") ;
-define("LABEL_dbMantenimiento","Manutenção da base de dados");
+define("LABEL_dbMantenimiento","Base de dados");  /* Used as menu entry. Keep it short */ 
 /*
 v 1.2
 */
 define('LABEL_relacion_vocabularioWebService',"relação com termo de um vocabulário-alvo remoto");
-define('LABEL_vocabulario_referenciaWS',"vocabulário-alvo remoto (web services)");
-define('LABEL_TargetVocabularyWS',"vocabulário-alvo remoto (web services)");
-define('LABEL_tvocab_label',"nome para referência");
-define('LABEL_tvocab_tag',"etiqueta para referência");
-define('LABEL_tvocab_uri_service',"URL para web services de referência");
-define('LABEL_targetTermsforUpdate',"termos com atualização pendente");
-define('LABEL_ShowTargetTermsforUpdate',"conferir atualização de termos");
-define('LABEL_enable',"habilitar");
-define('LABEL_disable',"disabilitar");
+define('LABEL_vocabulario_referenciaWS',"vocabulário-alvo remoto (serviços web)");
+define('LABEL_TargetVocabularyWS',"vocabulário-alvo remoto (serviços web)");
+define('LABEL_tvocab_label',"nome para a referência");
+define('LABEL_tvocab_tag',"etiqueta para a referência");
+define('LABEL_tvocab_uri_service',"URL para o serviço web da referência");
+define('LABEL_targetTermsforUpdate',"termos com atualizações pendentes");
+define('LABEL_ShowTargetTermsforUpdate',"verificar atualização de termos");
+define('LABEL_enable',"ativar");
+define('LABEL_disable',"desativar");
 define('LABEL_notFound',"termo não encontrado");
 define('LABEL_termUpdated',"termo atualizado");
 define('LABEL_ShowTargetTermforUpdate',"atualizar");
 define('LABEL_relbetweenVocabularies',"relações entre vocabulários");
-define('LABEL_update1_1x1_2',"Atualizar Tematres (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"A Tematres (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"termo externo (mapeamento terminológico)");
+define('LABEL_update1_1x1_2',"Atualizar (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Atualizar (1.0x -> 1.3)");
+define('LABEL_TargetTerm',"mapeamento terminológico");
 define('LABEL_TargetTerms',"termos externos (mapeamento terminológico)");
 define('LABEL_seleccionar','selecionar');
-define('LABEL_poliBT','mais de um termo geral');
+define('LABEL_poliBT','mais de um termo genérico');
 define('LABEL_FORM_simpleReport','Relatórios');
 define('LABEL_FORM_advancedReport','relatórios avançados');
-define('LABEL_FORM_nullValue','não importa');
-define('LABEL_FORM_haveNoteType','tem nota do tipo');
+define('LABEL_FORM_nullValue','Qualquer');
+define('LABEL_FORM_haveNoteType','tem nota de tipo');
 define('LABEL_haveEQ','tem equivalências');
 define('LABEL_nohaveEQ','sem equivalências');
-define('LABEL_start','que começam com');
+define('LABEL_start','que começam por');
 define('LABEL_end','terminam em');
 define('LABEL_equalThisWord','iguais a');
-define('LABEL_haveWords','inclui palavras');
+define('LABEL_haveWords','incluem palavras');
 define('LABEL_encode','codificação');
 /*
 v1.21
 */
 define('LABEL_import_skos','Importar Skos-Core');
-define('IMPORT_skos_file_already_exists','Já existe uma fonte Skos-Core');
+define('IMPORT_skos_file_already_exists','Já existe uma fonte Skos-Core no servidor');
 define('IMPORT_skos_form_legend','Importar Skos-Core');
-define('IMPORT_skos_form_label','Arquivo Skos-Core');
+define('IMPORT_skos_form_label','Ficheiro Skos-Core');
 /*
 v1.4
 */
-define('LABEL_termsxNTterms','Termos segundo quantidade de termos específicos');
+define('LABEL_termsxNTterms','Termos por quantidade de termos específicos');
 define('LABEL_termsNoBT','Termos sem relações hierárquicas');
 define('MSG_noTermsNoBT','Não existem termos sem relações hierárquicas');
 define('LABEL_termsXcantWords','Termos por quantidade de palavras');
-define('LABEL__USE_CODE','permitir código identificador único por termo');
-define('LABEL__SHOW_CODE','publicar código identificador único por termo');
-define('LABEL_CFG_MAX_TREE_DEEP','Nível máximo de profundidade para visualização da árvore');
-define('LABEL_CFG_VIEW_STATUS','publicar detalhes do estado dos termos');
-define('LABEL_CFG_SIMPLE_WEB_SERVICE','habilitar web services');
-define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','quantidade de termos para visualização de listas segundo estados');
-define('LABEL_CFG_MIN_SEARCH_SIZE','número mínimo de caracteres para busca');
-define('LABEL__SHOW_TREE','publicar navegação hierárquica na página inicial');
-define('LABEL__PUBLISH_SKOS','permitir consultas SKOS-Core através de web services. Isto pode expor todo seu vocabulário.');
-define('LABEL_update1_3x1_4',"Atualizar Tematres (1.3x -> 1.4)");
+define('LABEL__USE_CODE','usar código identificador único para ordenar termos');
+define('LABEL__SHOW_CODE','mostrar código identificador único ao público');
+define('LABEL_CFG_MAX_TREE_DEEP','Nível máximo de profundidade da árvore de itens para visualização na página');
+define('LABEL_CFG_VIEW_STATUS','mostrar detalhes do estatuto dos termos ao público');
+define('LABEL_CFG_SIMPLE_WEB_SERVICE','ativar serviços web');
+define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','quantidade de termos a exibir nas listas por estatutos');
+define('LABEL_CFG_MIN_SEARCH_SIZE','número mínimo de caracteres nas operações de pesquisa');
+define('LABEL__SHOW_TREE','publicar navegação hierárquica na página de entrada');
+define('LABEL__PUBLISH_SKOS','permitir consultas SKOS-Core através de serviços web. Isto pode expor todo o seu vocabulário.');
+define('LABEL_update1_3x1_4',"Atualizar (1.3x -> 1.4)");
 define("FORM_LABEL_format_import","selecionar formato");
 define("LABEL_importTab","texto tabulado");
 define("LABEL_importTag","texto etiquetado");
 define("LABEL_importSkos","Skos-core");
 define("LABEL_configTypeNotes","Configurar tipos de notas");
 define("LABEL_notes","notas");
-define("LABEL_saved","salvo");
-define("FORM_JS_confirmDeleteTypeNote","Confirma que quer excluir este tipo de nota?");
+define("LABEL_saved","guardado");
+define("FORM_JS_confirmDeleteTypeNote","Pretende mesmo eliminar este tipo de nota?");
 /*
 v1.5
 */
@@ -346,55 +348,55 @@ define("LABEL_relationEditor","editor de relações");
 define("LABEL_relationDelete","eliminar relação");
 define('LABEL_relationSubType',"tipo de relação");
 define('LABEL_relationSubTypeCode',"código do tipo de relação");
-define('LABEL_relationSubTypeLabel',"legenda do tipo de relação");
+define('LABEL_relationSubTypeLabel',"Rótulo do tipo de relação");
 define('LABEL_optative',"opcional");
-define('FORM_JS_confirmDeleteTypeRelation','Confirma que quer excluir este tipo de relação?');
-define("LABEL_URItypeEditor","editor de tipos de links");
-define("LABEL_URIEditor","Gerenciar links relacionados ao termo");
-define("LABEL_URItypeDelete","excluir tipo de link");
-define('LABEL_URItype',"tipo de link");
-define('LABEL_URItypeCode',"endereço do tipo de link");
-define('LABEL_URItypeLabel',"legenda do tipo de link");
-define('FORM_JS_confirmDeleteURIdefinition','Confirma que quer excluir este tipo de link?');
+define('FORM_JS_confirmDeleteTypeRelation','Pretende mesmo eliminar este tipo de relação?');
+define("LABEL_URItypeEditor","editor de tipos de ligações");
+define("LABEL_URIEditor","Gerir ligações associadas ao termo");
+define("LABEL_URItypeDelete","eliminar tipo de ligação");
+define('LABEL_URItype',"tipo de ligação");
+define('LABEL_URItypeCode',"nome curto do tipo de ligação");
+define('LABEL_URItypeLabel',"rótulo do tipo de ligação");
+define('FORM_JS_confirmDeleteURIdefinition','Pretende mesmo eliminar este tipo de ligação?');
 define('LABEL_URI2term','recurso web');
-define('LABEL_URI2termURL','URL do link');
+define('LABEL_URI2termURL','URL da hiperligação');
 define('LABEL_update1_4x1_5','Atualizar (1.4 -> 1.5)');
-define('LABEL_Contributor','Co-autor/Colaborador');
-define('LABEL_Rights','Direitos autorais');
+define('LABEL_Contributor','Colaboradores');
+define('LABEL_Rights','Direitos de autor');
 define('LABEL_Publisher','Editora');
 /*
 v1.6
 */
-define('LABEL_Prev','anteriores');
-define('LABEL_Next','próximos');
+define('LABEL_Prev','anterior');
+define('LABEL_Next','seguinte');
 define('LABEL_PageNum','página de resultados número ');
-define('LABEL_selectMapMethod','Selecione  o método de mapeamento terminológico');
-define('LABEL_string2search','expressão de busca');
+define('LABEL_selectMapMethod','Selecione o método de mapeamento terminológico');
+define('LABEL_string2search','expressão de pesquisa');
 define('LABEL_reverseMappign','mapeamento reverso');
-define('LABEL_warningMassiverem','Você vai excluir esses dados em lote! Isto é IRREVERSÍVEL!');
+define('LABEL_warningMassiverem','Irá eliminar os dados marcados em lote! Isto é IRREVERSÍVEL!');
 define('LABEL_target_terms','termos mapeados a partir de vocabulários externos');
 define('LABEL_URI2terms','recursos web');
-define('MENU_massiverem','Excluir dados em lote');
+define('MENU_massiverem','Eliminar em lote');
 define('LABEL_more','mais');
 define('LABEL_less','menos');
 define('LABEL_lastChangeDate','data da última alteração');
 define('LABEL_update1_5x1_6','Atualizar (1.5 -> 1.6)');
-define('LABEL_login','acessar');
+define('LABEL_login','autenticar');
 define('LABEL_user_recovery_password','Obter uma nova senha');
-define('LABEL_user_recovery_password1','Por favor, digite seu e-mail. Receberá um link para criar uma nova senha por e-mail.');
+define('LABEL_user_recovery_password1','Por favor, indique o seu endereço de email. Receberá no seu email uma hiperligação para poder criar uma nova senha.');
 define('LABEL_mail_recoveryTitle','Recuperar senha');
 define('LABEL_mail_recovery_pass1','Alguém solicitou que seja alterada a senha da seguinte conta:');
-define('LABEL_mail_recovery_pass2','Nome de usuário: %s');
-define('LABEL_mail_recovery_pass3','Se estiver errado, ignore este e-mail.');
+define('LABEL_mail_recovery_pass2','Nome de utilizador: %s');
+define('LABEL_mail_recovery_pass3','Se tiver sido um errado, ignore este email e a senha não será alterada.');
 define('LABEL_mail_recovery_pass4','Para mudar a senha, visite o seguinte endereço:');
 define('LABEL_mail_passTitle','Nova senha ');
 define('LABEL_mail_pass1','Nova senha para ');
 define('LABEL_mail_pass2','Senha: ');
 define('LABEL_mail_pass3','Você pode alterá-la.');
-define('MSG_check_mail_link','Confira em seu e-mail o link de confirmação.');
-define('MSG_check_mail','Confira seu e-mail.');
-define('MSG_no_mail','Não foi possível enviar o e-mail.');
-define('LABEL_user_lost_password','Perdeu sua senha?');
+define('MSG_check_mail_link','Verifique a sua conta de correio pela mensagem com a hiperligação de confirmação.');
+define('MSG_check_mail','Verifique a sua conta de correio.');
+define('MSG_no_mail','Não foi possível enviar o email.');
+define('LABEL_user_lost_password','Perdeu a senha?');
 ## v1.7
 define('LABEL_includeMetaTerm','Incluir meta-termos');
 define('NOTE_isMetaTerm','É um meta-termo.');
@@ -407,33 +409,33 @@ define('LABEL_relatedTerms','termos relacionados');
 define('LABEL_nonPreferedTerms','termos não preferidos');
 define('LABEL_update1_6x1_7','Atualizar (1.6 -> 2.2)');
 define('LABEL_include_data','incluir');
-define('LABEL_updateEndpoint','Atualizar o ponto de consulta SPARQL');
-define('MSG__updateEndpoint','Continuar a atualizar os dados para serem expostos através do ponto de consulta SPARQL. Esta operação pode demorar vários minutos.');
+define('LABEL_updateEndpoint','Atualizar ponto SPARQL');
+define('MSG__updateEndpoint','Ao continuar, os dados serão atualizados para serem expostos através do ponto de consulta SPARQL. Esta operação pode demorar vários minutos.');
 define('MSG__updatedEndpoint','O ponto de consulta SPARQL está atualizado.');
 define('MSG__dateUpdatedEndpoint','Data da última atualização do ponto de consulta SPARQL');
-define('LABEL__ENABLE_SPARQL','Deverá atualizar o ponto de consulta: Menu Administração -> Manutenção da base de dados -> Atualizar ponto de consulta SPARQL.');
-define('MSG__disable_endpoint','O ponto de consulta SPARQL está desabilitado.');
-define('MSG__need2setup_endpoint','O ponto de consulta SPARQL precisa ser atualizado. Contate o administrador do sistema');
-define('LABEL_SPARQLEndpoint','SPARQL endpoint');
-define('LABEL_AgregarRTexist','associar a um termo existente');
-define('MENU_selectExistTerm','selecione termo existente');
-define("TT_terminos","Termos superiores");
+define('LABEL__ENABLE_SPARQL','Deverá atualizar o ponto de consulta: Menu Administração -> Gerir base de dados -> Atualizar SPARQL.');
+define('MSG__disable_endpoint','O ponto de consulta SPARQL está desativado.');
+define('MSG__need2setup_endpoint','O ponto de consulta SPARQL precisa de ser atualizado. Contacte o administrador do sistema.');
+define('LABEL_SPARQLEndpoint','Ponto de ligação SPARQL');
+define('LABEL_AgregarRTexist','Selecionar termos a associar como termo relacionado a ');
+define('MENU_selectExistTerm','selecionar termo existente');
+define("TT_terminos","Termos de topo");
 ## v1.72
 define('MSG__warningDeleteTerm','O termo <i>%s</i> será <strong>ELIMINADO</strong>.');
-define('MSG__warningDeleteTerm2row','Serão eliminadas <strong>todas</strong> as notas e relações terminológicas. Esta ação é IRREVERSÍVEL.');
+define('MSG__warningDeleteTerm2row','Serão eliminadas <strong>todas</strong> as notas e relações terminológicas. Esta ação é IRREVERSÍVEL!');
 ## v1.8
-define('LABEL__getForRecomendation','buscar recomendações');
-define('LABEL__getForRecomendationFor','buscar recomendações para');
-define('FORM_LABEL__contactMail','e-mail para contato');
+define('LABEL__getForRecomendation','obter sugestões');
+define('LABEL__getForRecomendationFor','obter sugestões para ');
+define('FORM_LABEL__contactMail','Email de contacto');
 define('LABEL_addMapLink','adicionar mapeamento entre vocabulários');
-define('LABEL_addExactLink','adicionar link de referência');
-define('LABEL_addSourceNote','adicionar nota de fonte');
+define('LABEL_addExactLink','adicionar hiperligação de referência');
+define('LABEL_addSourceNote','adicionar nota da fonte');
 ## v1.82
 define('LABEL_FORM_mappedTermReport','Relações entre vocabulários');
-define('LABEL_eliminar','Excluir');
+define('LABEL_eliminar','Eliminar');
 ##v.2
-define('MSG_termsNoDeleted','termos não foram excluídos');
-define('MSG_termsDeleted','termos excluídos');
+define('MSG_termsNoDeleted','os termos não foram eliminados');
+define('MSG_termsDeleted','termos eliminados');
 define('LABEL_selectAll','selecionar tudo');
 define('LABEL_metadatos','metadados');
 define('LABEL_totalTermsDescendants','termos descendentes');
@@ -441,78 +443,89 @@ define('LABEL_altTerms','termos alternativos');
 define('LABEL_narrowerTerms','termos específicos');
 define('LABEL_results','resultados');
 define('LABEL_showFreeTerms','lista de termos livres');
-define('LABEL_helpSearchFreeTerms','Serão buscados somente os termos livres.');
+define('LABEL_helpSearchFreeTerms','Serão pesquisados apenas os termos livres.');
 define('LABEL_broatherTerms','termos genéricos');
 define('LABEL_type2filter','digite para filtrar termos');
 define('LABEL_defaultEQmap','Utilize "eq" para indicar relação de equivalência');
-define("MSG_repass_error","as chaves não coincidem");
+define("MSG_repass_error","as senhas não coincidem");
 define("MSG_lengh_error","mínimo de %d caracteres");
-define("MSG_errorPostData","Ocorreu um erro, por favor revise os dados do campo ");
-define('LABEL_preferedTerms','termos preferidos');
+define("MSG_errorPostData","Ocorreu um erro, por favor, reveja os dados indicados no campo ");
+define('LABEL_preferedTerms','termos preferenciais');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','termos SEM notas');
-define('MSG_FORM_NULLnotesTermReport','termos sem notas do tipo');
-define('LABELnoNotes','termos sem nenhuma nota');
+define('MSG_FORM_NULLnotesTermReport','termos sem notas de tipo');
+define('LABELnoNotes','termos sem qualquer nota');
 define('LABEL_termsXdeepLevel','termos por nível hierárquico');
 define('LABEL_deepLevel','nível');
-define('LABEL_cantTerms','# de termos');
+define('LABEL_cantTerms','Qtd. de termos');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="Lista de vocabularios controlados conhecidos" target="_blank">Lista de vocabulários controlados conhecidos</a>');
 define('LABEL_showNewsTerm','ver alterações recentes');
 define('LABEL_newsTerm','alterações recentes');
-define('MSG_contactAdmin','contace o administador');
+define('MSG_contactAdmin','contacte o administador');
 define('LABEL_addTargetVocabulary','adicionar vocabulários de referência (serviços web terminológicos)');
 #v.2.1
 define('LABEL_duplicatedTerm','termo duplicado');
 define('LABEL_duplicatedTerms','termos duplicados');
 define('MSG_duplicatedTerms','A configuração do vocabulário não permite termos duplicados.');
-define('LABEL_bulkReplace','Edição em lote (localizar e substituir');
-define('LABEL_searchFor','Texto a localizar');
+define('LABEL_bulkReplace','edição em lote (localizar e substituir)');
+define('LABEL_searchFor','texto a procurar');
 define('LABEL_replaceWith','substituir por');
 define('LABEL_bulkNotesWillReplace','notas serão modificadas');
 define('LABEL_bulkNotesReplaced','notas foram modificadas');
 define('LABEL_bulkTermsWillReplace','termos serão modificados');
 define('LABEL_bulkTermsReplaced','termos foram modificados');
-define('LABEL_termMOD','termo modificado');
-define('LABEL_noteMOD','nota modificada');
-define('MENU_bulkEdition','Edição em lote');
-define('MSG_searchFor','texto que deseja localizar (sensível a maiúsculas)');
+define('LABEL_termMOD','termos modificados');
+define('LABEL_noteMOD','notas modificadas');
+define('MENU_bulkEdition','edição em lote');
+define('MSG_searchFor','texto que deseja encontrar (sensível a maiúsculas)');
 define('MSG_replaceWith','texto substituto (sensível a maiúsculas)');
 define('LABEL_warningBulkEditor','Os dados serão modificados em lote. Esta ação é IRREVERSÍVEL!');
-define('LABEL_CFG_SUGGESTxWORD','sugerir termo conforme palavras ou frases?');
+define('LABEL_CFG_SUGGESTxWORD','sugerir termos por palavras ou frases?');
 define('LABEL_ALLOW_DUPLICATED','permitir termos duplicados?');
 define('LABEL_CFG_PUBLISH','O vocabulário terá acesso público?');
 define('LABEL_Replace','substituir');
-define('LABEL_Preview','preview');
+define('LABEL_Preview','Pré-visualizar');
 #v.2.2
 define('LABEL_selectRelation','selecionar relação');
 define('LABEL_withSelected','com os selecionados:');
-define('LABEL_rejectTerms','reprovar termos');
-define('LABEL_doMetaTerm','converter em meta-termo');
-define('LABEL_associateFreeTerms','vincular como UF,TE o TR');
+define('LABEL_rejectTerms','rejeitar termos');
+define('LABEL_doMetaTerm','converter em meta-termos');
+define('LABEL_associateFreeTerms','associar como UP, TE o TR');
 define('MSG_associateFreeTerms','no próximo passo é possível escolher o tipo de relação.');
 define('MSG_termsSuccessTask','termos afetados pela operação');
 define('LABEL_TTTerms','termos de topo');
 define('MSG__GLOSSincludeAltLabel','incluir termos alternativos');
-define('MSG__GLOSSdocumentationJSON','A fonte JSON do glossário pode ser integrada com qualquer conteúdo HTML por meio da biblioteca <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
-define('LABEL_configGlossary','exportar fonte de dados para glossário');
+define('MSG__GLOSSdocumentationJSON','A fonte JSON do glossário pode ser integrada com qualquer conteúdo HTML utilizando a biblioteca <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
+define('LABEL_configGlossary','exportar glossário como fonte de dados');
 define('MSG_includeNotes','utilizar notas do tipo:');
 define('LABEL_SHOW_RANDOM_TERM','exibir um termo aleatório na página inicial. É necessário escolher um tipo de nota.');
-define('LABEL_opt_show_rando_term','exibir termos com nota tipo:');
-define('MSG_helpNoteEditor','Associe termos utilizando colchetes duplos. Ex: Só o [[amor]] salvará o mundo');
-define('LABEL_GLOSS_NOTES','Selecionar tipo de nota para glosar termos marcados com colchetes dobles: [[glossário]]');
+define('LABEL_opt_show_rando_term','exibir termos com nota de tipo:');
+define('MSG_helpNoteEditor','Pode associar termos utilizando parenteses retos duplos. Ex: Só o [[amor]] salvará o mundo');
+define('LABEL_GLOSS_NOTES','Selecionar o tipo de nota que será usada para explicitar (glosar) os termos marcados com parenteses retos: [[glossario]]');
+define('LABEL_bulkGlossNotes','tipo de nota a glosar');
+define('MSG__autoGlossInfo','Este proceso associa os termos existentes no vocabulário às suas menções nas notas. É utilizada a notação Wiki (Ex.: Só o [[amor]] salvará o mundo). Corresponde a uma operação de pesquisa e substituição de texto <strong>sensível a maiúsculas</strong>.');
+define('MSG__autoGlossDanger','Esta operação altera os dados de forma IRREVERSÍVEL. Antes de continuar, efetue uma cópia de segurança.');
+define('LABEL_replaceBinary','Sensível a maiúsculas e acentos');
+define('MSG_notesAffected','notas afetadas');
+define('MSG_cantTermsFound','termos encontrados');
+define('MENU_glossConfig','Glossário automático'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','criação de glossário automático');
 define('LABEL_AlphaPDF','Alfabético (PDF)');
 define('LABEL_SystPDF','Sistemático (PDF)');
 define('LABEL_references','referências');
 define('LABEL_printData','data de impressão');
 ##v.3
-define('MENU_bulkTranslate','editor multilingüe');
+define('MENU_bulkTranslate','editor multilingue');
 define('LABEL_bulkTranslate','editor de traduções e equivalências');
-define('LABEL_termsEQ','com correspondências');
-define('LABEL_termsNoEQ','sem correspondências');
+define('LABEL_termsEQ','com equivalências');
+define('LABEL_termsNoEQ','sem equivalências');
 define('LABEL_close','fechar');
 define('LABEL_allTerms','todos os termos');
 define('LABEL_allNotes','todas as notas');
 define('LABEL_allRelations','todas as relações entre termos');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Tradução pela comunidade para TemaTres.'); /* Do not include emails or personal details */
 
-##?
-define('MENU_glossConfig','Configurações do glossário');
 ?>

--- a/common/lang/ru-utf-8.inc.php
+++ b/common/lang/ru-utf-8.inc.php
@@ -1,21 +1,23 @@
 <?php
-#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#   TemaTres: open source thesaurus management #       #
 #                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
 #   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
-#   Maribel Cuadrado
-# 2014-03-06 jsau arreglant i completant catala
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
+#
 ###############################################################################################################
 #
 define("LANG","ru");
-define("TR_acronimo","RT");
-define("TE_acronimo","NT");
-define("TG_acronimo","BT");
-define("UP_acronimo","UF");
+define("TR_acronimo","RT"); /* Related Term */
+define("TE_acronimo","NT"); /* Narrower term > Specific term */
+define("TG_acronimo","BT"); /* Broader term > Generic term */
+define("UP_acronimo","UF"); /* Used for > instead */
 define("TR_termino","Взаимосвязанный термин");
 define("TE_termino","Термин с более узким значением");
 define("TG_termino","Термин с более общим значением");
-define("UP_termino","Использовать для");
-define("USE_termino","ИСПОЛЬЗОВАТЬ");
+define("UP_termino","Использовать для"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
+/* v 9.5 */
+define("USE_termino","ИСПОЛЬЗОВАТЬ"); /* A term with this symbol is followed by a preferred term (descriptor) */
 define("MENU_ListaSis","Иерархический список");
 define("MENU_ListaAbc","Алфавитный список");
 define("MENU_Sobre","О...");
@@ -30,7 +32,7 @@ define("MENU_BorrarT","Удалить термин");
 define("MENU_AgregarTG","Определить статус термина");
 define("MENU_AgregarTE","Субтермин");
 define("MENU_AgregarTR","Взаимосвязанный термин");
-define("MENU_AgregarUP","нежелательный термин");
+define("MENU_AgregarUP","нежелательный термин");  /* Non-descriptor */
 define("MENU_MisDatos","Моя учетная запись");
 define("MENU_Caducar","отключить");
 define("MENU_Habilitar","доступен");
@@ -71,7 +73,7 @@ define("LABEL_DatosUser","Данные пользователя");
 define("LABEL_Acciones","Задания");
 define("LABEL_verEsquema","показать схему");
 define("LABEL_actualizar","Обновить");
-define("LABEL_terminosLibres","Свободные термины");
+define("LABEL_terminosLibres","Свободные термины"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
 define("LABEL_busqueda","Поиск");
 define("LABEL_borraRelacion","удалить взаимосвязь");
 define("MSG_ResultBusca","термины, найденные для выражения поиска");
@@ -118,8 +120,8 @@ define("LABEL_verDetalle","см. детали ");
 define("LABEL_verTerminosLetra","см. термины, начинающиеся с ");
 define("LABEL_NB","Библиографическое примечание");
 define("LABEL_NH","Историческое примечание");
-define("LABEL_NA","Примечание по области применения");
-define("LABEL_NP","Индивидуальное примечание");
+define("LABEL_NA","Примечание по области применения");   /* version 0.9.1 */
+define("LABEL_NP","Индивидуальное примечание"); /* version 0.9.1 */
 define("LABEL_EditorNota","Редактор примечаний ");
 define("LABEL_EditorNotaTermino","примечание для ");
 define("LABEL_tipoNota","тип примечания");
@@ -130,11 +132,13 @@ define("LABEL_EditarNota","редактировать примечание");
 define("LABEL_EliminarNota","Удалить примечание");
 define("LABEL_OptimizarTablas","Оптимизировать таблицы");
 define("LABEL_TotalZthesLine","Экспортировать в Zthes");
+/* v 9.2 */
 define("LABEL_negrita","жирный");
 define("LABEL_italica","курсив");
 define("LABEL_subrayado","подчеркивание");
 define("LABEL_textarea","текст примечаний");
 define("MSGL_relacionIlegal","неверная взаимосвязь между терминами");
+/* v 9.3 */
 define("LABEL_fecha_modificacion","изменено");
 define("LABEL_TotalUsuarios","всего пользователей");
 define("LABEL_TotalTerminos","всего терминов");
@@ -147,12 +151,28 @@ define("LABEL_terminosRepetidos","дублирование терминов");
 define("MSG_noTerminosLibres","свободные термины отсутствуют");
 define("MSG_noTerminosRepetidos","дубликаты терминов отсутствуют");
 define("LABEL_TotalSkosLine","экспортировать в Skos-core");
+$MONTHS=array("01"=>"Янв",
+              "02"=>"Фев",
+              "03"=>"Март",
+              "04"=>"Март",
+              "05"=>"Май",
+              "06"=>"Июнь",
+              "07"=>"Июль",
+              "08"=>"Авг",
+              "09"=>"Сен",
+              "10"=>"Сен",
+              "11"=>"Ноя",
+              "12"=>"Дек"
+              );
+/* v 9.4 */
 define("LABEL_SI","ДА");
 define("LABEL_NO","НЕТ");
 define("FORM_LABEL_jeraquico","полииерархический");
-define("LABEL_jeraquico","Полииерархический");
+define("LABEL_jeraquico","Полииерархический"); /* Polyhierarchical relationship */
 define("LABEL_terminoLibre","свободный термин");
+/* v 9.5 */
 define("LABEL_URL_busqueda","Искать %s в:");
+/* v 9.6 */
 define("LABEL_relacion_vocabulario","связь с другим словарем");
 define("FORM_LABEL_relacion_vocabulario","эквивалентность");
 define("FORM_LABEL_nombre_vocabulario","словарь языка перевода");
@@ -164,20 +184,22 @@ define("LABEL_tipo_vocabulario","тип");
 define("LABEL_termino_equivalente","эквивалент");
 define("LABEL_termino_parcial_equivalente","частичный эквивалент");
 define("LABEL_termino_no_equivalente","не эквивалент");
-define("EQ_acronimo","EQ");
-define("EQP_acronimo","EQP");
-define("NEQ_acronimo","NEQ");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
 define("LABEL_NC","Примечание к каталогизатору");
 define("LABEL_resultados_suplementarios","дополнительные результаты");
 define("LABEL_resultados_relacionados","взаимосвязанные результаты");
+/* v 9.7 */
 define("LABEL_export","экспорт");
 define("FORM_LABEL_format_export","выбрать схему XML ");
+/* v 1.0 */
 define("LABEL_fecha_creacion","создано");
-define("NB_acronimo","BN");
-define("NH_acronimo","HN");
-define("NA_acronimo","SN");
-define("NP_acronimo","PN");
-define("NC_acronimo","CN");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
 define("LABEL_Candidato","предлагаемый термин");
 define("LABEL_Aceptado","одобренный термин");
 define("LABEL_Rechazado","отклоненный термин");
@@ -188,70 +210,92 @@ define("LABEL_Aceptados","одобренные термины");
 define("LABEL_Rechazados","отклоненные термины");
 define("LABEL_User_NoHabilitado","отключить");
 define("LABEL_User_Habilitado","включить");
+
 define("LABEL_CandidatearTermino","предложить термин");
 define("LABEL_AceptarTermino","одобрить термин");
 define("LABEL_RechazarTermino","отклонить термин");
+/* v 1.01 */
 define("LABEL_TERMINO_SUGERIDO","Вы имели в виду:");
+/* v 1.02 */
 define("LABEL_esSuperUsuario","является администратором");
 define("LABEL_Cancelar","отменить");
 define("LABEL_Guardar","сохранить");
+/* v 1.033 */
 define("MENU_AgregarTEexist","Определить статус существующего термина");
 define("MENU_AgregarUPexist","Присоединить существующий нежелательный термин ");
 define("LABEL_existAgregarUP","Добавить термин UF к %s");
 define("LABEL_existAgregarTE","Добавить термин с более узким значением к %s ");
 define("MSG_minCharSerarch","Выражение поиска <i>%s</i> содержит только <strong>%s </strong> символы. Должно содержать другие данные помимо <strong>%s</strong> символов");
+/* v 1.04 */
 define("LABEL_terminoExistente","существующий термин");
 define("HELP_variosTerminos","Чтобы добавить несколько терминов сразу, укажите по <strong>одному термину в каждой линии</strong>.");
-define("FORM","Форма");
-define("ERROR","Ошибка");
-define("LABEL_bienvenida","Добро пожаловать на сервер словаря TemaTres");
-define("PARAM_SERVER","Адрес сервера");
-define("PARAM_DBName","Название базы данных");
-define("PARAM_DBLogin","Пользователь базы данных");
-define("PARAM_DBPass","Пароль базы данных");
-define("PARAM_DBprefix","Таблицы префиксов");
-define("MSG_ERROR_CODE","invalid code");
-define("LABEL_CODE","code");
-define("LABEL_Ver","Show");
-define("LABEL_OpcionesTermino","term");
-define('LABEL_CambiarEstado',"Change term status");
-define('LABEL_ClickEditar',"Click to edit...");
-define('LABEL_TopTerm',"Has this top term");
-define('LABEL_esFraseExacta',"exact phrase");
-define('LABEL_DesdeFecha',"created on or after");
-define('LABEL_ProfundidadTermino',"is located in deep level");
-define('LABEL_esNoPreferido',"non preferred term");
-define('LABEL_BusquedaAvanzada',"advanced search");
-define('LABEL_Todos',"all");
-define('LABEL_QueBuscar',"what search?");
-define('LABEL_import','импорт');
-define('IMPORT_form_legend','импортировать тезаурус из файла');
-define('IMPORT_form_label','файл');
-define('IMPORT_file_already_exists','txt файл уже имеется на сервере');
-define('IMPORT_file_not_exists','txt файл еще не импортирован');
-define('IMPORT_do_it','Можно начинать импорт');
-define('IMPORT_working','выполняется импорт');
-define('IMPORT_finish','импорт закончен');
-define('LABEL_reIndice','восстановить индексы');
-define('LABEL_dbMantenimiento','обслуживание базы данных');
-define('LABEL_relacion_vocabularioWebService',"relation with term from remote target vocabulary");
-define('LABEL_vocabulario_referenciaWS',"remote target vocabulary (web  services)");
-define('LABEL_TargetVocabularyWS',"remote target vocabulary (web  services)");
-define('LABEL_tvocab_label',"label for the reference");
-define('LABEL_tvocab_tag',"tag for the reference");
-define('LABEL_tvocab_uri_service',"URL for the web services reference");
-define('LABEL_targetTermsforUpdate',"terms with pending update");
-define('LABEL_ShowTargetTermsforUpdate',"check terms update");
-define('LABEL_enable',"enable");
-define('LABEL_disable',"disable");
-define('LABEL_notFound',"term not found");
-define('LABEL_termUpdated',"term updated");
-define('LABEL_ShowTargetTermforUpdate',"update");
-define('LABEL_relbetweenVocabularies',"relations between vocabularies");
-define('LABEL_update1_1x1_2',"Update (1.1 -> 1.3)");
-define('LABEL_update1x1_2',"Update (1.0x -> 1.3)");
-define('LABEL_TargetTerm',"terminological mapping");
-define('LABEL_TargetTerms',"terms (terminological mapping)");
+/* Install messages */
+define("FORM","Форма") ;
+define("ERROR","Ошибка") ;
+define("LABEL_bienvenida","Добро пожаловать на сервер словаря TemaTres") ;
+// COMMON SQL
+define("PARAM_SERVER","Адрес сервера") ;
+define("PARAM_DBName","Название базы данных") ;
+define("PARAM_DBLogin","Пользователь базы данных") ;
+define("PARAM_DBPass","Пароль базы данных") ;
+define("PARAM_DBprefix","Таблицы префиксов") ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
+$install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+/* end Install messages */
+/* v 1.1 */
+define('MSG_ERROR_CODE',"неверный код");
+define('LABEL_CODE',"код");
+define('LABEL_Ver',"Показать");
+define('LABEL_OpcionesTermino',"термин");
+define('LABEL_CambiarEstado',"Изменить статус термина");
+define('LABEL_ClickEditar',"Нажать для редактирования...");
+define('LABEL_TopTerm',"Имеет этот верхний термин");
+define('LABEL_esFraseExacta',"точная фраза");
+define('LABEL_DesdeFecha',"создано на дату или после");
+define('LABEL_ProfundidadTermino',"расположен в глубоком уровне");
+define('LABEL_esNoPreferido',"нежелательный термин");
+define('LABEL_BusquedaAvanzada',"расширенный поиск");
+define('LABEL_Todos',"все");
+define('LABEL_QueBuscar',"что искать?");
+define("LABEL_import","импорт") ;
+define("IMPORT_form_legend","импортировать тезаурус из файла") ;
+define("IMPORT_form_label","файл") ;
+define("IMPORT_file_already_exists","txt файл уже имеется на сервере") ;
+define("IMPORT_file_not_exists","txt файл еще не импортирован") ;
+define("IMPORT_do_it","Можно начинать импорт") ;
+define("IMPORT_working","выполняется импорт") ;
+define("IMPORT_finish","импорт закончен") ;
+define("LABEL_reIndice","восстановить индексы") ;
+define("LABEL_dbMantenimiento","обслуживание базы данных");  /* Used as menu entry. Keep it short */ 
+/*
+v 1.2
+*/
+define('LABEL_relacion_vocabularioWebService',"соотношение с термином из удаленного конечного словаря");
+define('LABEL_vocabulario_referenciaWS',"удаленный конечный словарь (интернет-услуги)");
+define('LABEL_TargetVocabularyWS',"удаленный конечный словарь (интернет-услуги)");
+define('LABEL_tvocab_label',"метка для справки");
+define('LABEL_tvocab_tag',"тэг для справки");
+define('LABEL_tvocab_uri_service',"URL для ссылки на интернет-услуги");
+define('LABEL_targetTermsforUpdate',"термины с ожиданием обновления");
+define('LABEL_ShowTargetTermsforUpdate',"проверить обновление терминов");
+define('LABEL_enable',"включить");
+define('LABEL_disable',"отключить");
+define('LABEL_notFound',"термин не найден");
+define('LABEL_termUpdated',"термин обновлен");
+define('LABEL_ShowTargetTermforUpdate',"обновить");
+define('LABEL_relbetweenVocabularies',"взаимосвязь между словарями");
+define('LABEL_update1_1x1_2',"Обновить (1.1 -> 1.3)");
+define('LABEL_update1x1_2',"Обновить (1.0x -> 1.3)");
+define('LABEL_TargetTerm',"терминологическое картирование");
+define('LABEL_TargetTerms',"термины (терминологическое картирование)");
 define('LABEL_seleccionar','выбрать');
 define('LABEL_poliBT','более одного термина с более общим значением');
 define('LABEL_FORM_simpleReport','отчеты');
@@ -265,10 +309,16 @@ define('LABEL_end','заканчивается на');
 define('LABEL_equalThisWord','точное совпадение с');
 define('LABEL_haveWords','содержит слова');
 define('LABEL_encode','кодировка');
+/*
+v1.21
+*/
 define('LABEL_import_skos','Импорт Skos-Core');
 define('IMPORT_skos_file_already_exists','Источник Skos-Core находится на сервере');
 define('IMPORT_skos_form_legend','Импорт Skos-Core');
 define('IMPORT_skos_form_label','Файл Skos-Core');
+/*
+v1.4
+*/
 define('LABEL_termsxNTterms','Термины с более узким значением х термин');
 define('LABEL_termsNoBT','Термины без иерархической взаимосвязи');
 define('MSG_noTermsNoBT','Термины без иерархической взаимосвязи отсутствуют');
@@ -283,24 +333,27 @@ define('LABEL_CFG_MIN_SEARCH_SIZE','Минимальное количество 
 define('LABEL__SHOW_TREE','опубликовать иерархический вид на главной странице');
 define('LABEL__PUBLISH_SKOS','включить формат Skos-core для веб-услуг. Это может привести к открытию доступа ко всему Вашему словарю.');
 define('LABEL_update1_3x1_4',"Update (1.3x -> 1.4)");
-define('FORM_LABEL_format_import','выбрать формат');
-define('LABEL_importTab','табулированный текст');
-define('LABEL_importTag','тегированный текст');
-define('LABEL_importSkos','Skos-core');
-define('LABEL_configTypeNotes','конфигурировать типы примечаний');
-define('LABEL_notes','примечания');
-define('LABEL_saved','сохранено');
-define('FORM_JS_confirmDeleteTypeNote','удалить этот тип примечания?');
-define('LABEL_relationEditor','редактор взаимосвязей');
-define('LABEL_relationDelete','удалить подтип взаимосвязи');
+define("FORM_LABEL_format_import","выбрать формат");
+define("LABEL_importTab","табулированный текст");
+define("LABEL_importTag","тегированный текст");
+define("LABEL_importSkos","Skos-core");
+define("LABEL_configTypeNotes","конфигурировать типы примечаний");
+define("LABEL_notes","примечания");
+define("LABEL_saved","сохранено");
+define("FORM_JS_confirmDeleteTypeNote","удалить этот тип примечания?");
+/*
+v1.5
+*/
+define("LABEL_relationEditor","редактор взаимосвязей");
+define("LABEL_relationDelete","удалить подтип взаимосвязи");
 define('LABEL_relationSubType',"relation type");
 define('LABEL_relationSubTypeCode',"relation sub-type alias");
 define('LABEL_relationSubTypeLabel',"relation sub-type label");
-define('LABEL_optative',"opcional");
+define('LABEL_optative',"optional");
 define('FORM_JS_confirmDeleteTypeRelation','удалить этот подтип взаимосвязи?');
-define('LABEL_URItypeEditor','редактор типов ссылок');
-define('LABEL_URIEditor','управление ссылками, касающимися термина');
-define('LABEL_URItypeDelete','удалить тип ссылки');
+define("LABEL_URItypeEditor","редактор типов ссылок");
+define("LABEL_URIEditor","управление ссылками, касающимися термина");
+define("LABEL_URItypeDelete","удалить тип ссылки");
 define('LABEL_URItype',"link type");
 define('LABEL_URItypeCode',"link type alias");
 define('LABEL_URItypeLabel',"link type label");
@@ -311,6 +364,9 @@ define('LABEL_update1_4x1_5','Обновить (1.4 -> 1.5)');
 define('LABEL_Contributor','автор');
 define('LABEL_Rights','права');
 define('LABEL_Publisher','публикатор');
+/*
+v1.6
+*/
 define('LABEL_Prev','предыдущий');
 define('LABEL_Next','следующий');
 define('LABEL_PageNum','номер страницы с результатами ');
@@ -341,6 +397,7 @@ define('MSG_check_mail_link','Ссылка подтверждения отпра
 define('MSG_check_mail','Проверьте Вашу электронную почту.');
 define('MSG_no_mail','Сообщение не было отправлено.');
 define('LABEL_user_lost_password',' Забыли пароль?');
+## v1.7
 define('LABEL_includeMetaTerm','Содержит мета-термины');
 define('NOTE_isMetaTerm','Является мета-термином.');
 define('NOTE_isMetaTermNote','Мета-термин – это термин, который невозможно использовать в процессе индексирования. Термин, используемый для описания других терминов. Например: направляющие термины, аспекты, категории и др.');
@@ -362,67 +419,13 @@ define('MSG__need2setup_endpoint','Необходимо обновить кон�
 define('LABEL_SPARQLEndpoint','Конечная точка SPARQL');
 define('LABEL_AgregarRTexist','Выберите термины, которые будут указаны в качестве взаимосвязанного термина с');
 define('MENU_selectExistTerm','выберите существующий термин');
-define('TT_terminos','популярные термины');
+define("TT_terminos","популярные термины");
+## v1.72
 define('MSG__warningDeleteTerm','Термин <i>%s</i> будет <strong>УДАЛЕН</strong>.');
 define('MSG__warningDeleteTerm2row','Его примечания и взаимосвязи <strong>all</strong> будут удалены. Это действие не подлежит отмене!');
-$MONTHS=array("01"=>"Янв",
-              "02"=>"Фев",
-              "03"=>"Март",
-              "04"=>"Март",
-              "05"=>"Май",
-              "06"=>"Июнь",
-              "07"=>"Июль",
-              "08"=>"Авг",
-              "09"=>"Сен",
-              "10"=>"Сен",
-              "11"=>"Ноя",
-              "12"=>"Дек"
-              );
-define('install_message[101]','Настройка TemaTres ');
-define('install_message[201]','Не удалось найти конфигурацию файла для связи с базой данных (%s). ');
-define('install_message[202]','Конфигурация файла для связи с базой данных найдена. ');
-define('install_message[203]','Не удалось установить связь сервера базы данных <em>%s</em> с пользователем <em>%s</em>. Проверьте конфигурацию файла для связи с базой данных (%s). ');
-define('install_message[204]','Связь с сервером <em>%s</em> установлена ');
-define('install_message[205]','Не удалось установить связь с базой данных <em>%s</em> на сервере <em>%s</em>. Проверьте конфигурацию файла для связи с базой данных (%s). ');
-define('install_message[206]','Связь с базой данных <em>%s</em> на сервере <em>%s</em> установлена. ');
-define('install_message[301]','Увы... Пример конфигурации Tematres уже существует. Проверьте конфигурацию файла для связи с базой данных (%s). <a href="index.php">Enjoy your Vocabulary Server</a>');
-define('install_message[305]',' Проверка пароля безопасности. ');
-define('install_message[306]','Настройка выполнена, <a href="index.php">Можете пользоваться сервером словаря</a>' );
-define("MSG_ERROR_CODE","неверный код");
-define("LABEL_CODE","код");
-define("LABEL_Ver","Показать");
-define("LABEL_OpcionesTermino","термин");
-define("LABEL_CambiarEstado","Изменить статус термина");
-define("LABEL_ClickEditar","Нажать для редактирования...");
-define("LABEL_TopTerm","Имеет этот верхний термин");
-define("LABEL_esFraseExacta","точная фраза");
-define("LABEL_DesdeFecha","создано на дату или после");
-define("LABEL_ProfundidadTermino","расположен в глубоком уровне");
-define("LABEL_esNoPreferido","нежелательный термин");
-define("LABEL_BusquedaAvanzada","расширенный поиск");
-define("LABEL_Todos","все");
-define("LABEL_QueBuscar","что искать?");
-define("LABEL_relacion_vocabularioWebService","соотношение с термином из удаленного конечного словаря");
-define("LABEL_vocabulario_referenciaWS","удаленный конечный словарь (интернет-услуги)");
-define("LABEL_TargetVocabularyWS","удаленный конечный словарь (интернет-услуги)");
-define("LABEL_tvocab_label","метка для справки");
-define("LABEL_tvocab_tag","тэг для справки");
-define("LABEL_tvocab_uri_service","URL для ссылки на интернет-услуги");
-define("LABEL_targetTermsforUpdate","термины с ожиданием обновления");
-define("LABEL_ShowTargetTermsforUpdate","проверить обновление терминов");
-define("LABEL_enable","включить");
-define("LABEL_disable","отключить");
-define("LABEL_notFound","термин не найден");
-define("LABEL_termUpdated","термин обновлен");
-define("LABEL_ShowTargetTermforUpdate","обновить");
-define("LABEL_relbetweenVocabularies","взаимосвязь между словарями");
-define("LABEL_update1_1x1_2","Обновить (1.1 -> 1.3)");
-define("LABEL_update1x1_2","Обновить (1.0x -> 1.3)");
-define("LABEL_TargetTerm","терминологическое картирование");
-define("LABEL_TargetTerms","термины (терминологическое картирование)");
 ## v1.8
 define('LABEL__getForRecomendation','get for recommendations');
-define('LABEL__getForRecomendationFor','get for recommendations to');
+define('LABEL__getForRecomendationFor','get for recommendations to ');
 define('FORM_LABEL__contactMail','contact mail');
 define('LABEL_addMapLink','add mapping between vocabularies');
 define('LABEL_addExactLink','add reference link');
@@ -431,7 +434,7 @@ define('LABEL_addSourceNote','add source note');
 define('LABEL_FORM_mappedTermReport','Relationships between vocabularies');
 define('LABEL_eliminar','Delete');
 ##v.2
-define('MSG_termsNoDeleted','the terms was deleted');
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','deleted terms');
 define('LABEL_selectAll','select all');
 define('LABEL_metadatos','metadata');
@@ -444,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','Only free terms.');
 define('LABEL_broatherTerms','broader Terms');
 define('LABEL_type2filter','type to filter the terms');
 define('LABEL_defaultEQmap','Type "eq" to define equivalence relationship');
-define("MSG_repass_error","the passwords are not matched");
-define("MSG_lengh_error","please type at least %d caracteres");
-define("MSG_errorPostData","A mistake was detected, Please review the data to the field");
-define('LABEL_preferedTerms','preferred terms');
+define("MSG_repass_error","the passwords do not match");
+define("MSG_lengh_error","please type at least %d characters");
+define("MSG_errorPostData","A mistake was detected, Please review the data to the field ");
+define('LABEL_preferedTerms','preferred terms');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','terms WITHOUT notes');
 define('MSG_FORM_NULLnotesTermReport','terms without note type');
 define('LABELnoNotes','terms that have no note');
@@ -457,12 +460,12 @@ define('LABEL_cantTerms','# of terms');
 define('LINK_publicKnownVocabularies','<a href="http://www.vocabularyserver.com/vocabularies/" title="List of enabled vocabularies" target="_blank">List of enabled vocabularies</a>');
 define('LABEL_showNewsTerm','show recent changes');
 define('LABEL_newsTerm','recent changes');
-define('MSG_contactAdmin','contact to the administrator');
+define('MSG_contactAdmin','contact the administrator');
 define('LABEL_addTargetVocabulary','add external vocabularies (terminological web services)');
 #v.2.1
 define('LABEL_duplicatedTerm','duplicated term');
 define('LABEL_duplicatedTerms','duplicated terms');
-define('MSG_duplicatedTerms','The configuration of the vocabulary not allow duplicate terms.');
+define('MSG_duplicatedTerms','The configuration of the vocabulary does not allow duplicate terms.');
 define('LABEL_bulkReplace','bulk editor (search and replace)');
 define('LABEL_searchFor','string to search and replace');
 define('LABEL_replaceWith','replace with');
@@ -478,7 +481,7 @@ define('MSG_replaceWith','Input text you want to replace with (case sensitive)')
 define('LABEL_warningBulkEditor','You will modify data massively. These actions are irreversible!');
 define('LABEL_CFG_SUGGESTxWORD','suggest terms by words or phrases?');
 define('LABEL_ALLOW_DUPLICATED','enable duplicate terms?');
-define('LABEL_CFG_PUBLISH','Is the vocabulary can be consulted by anyone?');
+define('LABEL_CFG_PUBLISH','Publish the vocabulary so anyone can view it?');
 define('LABEL_Replace','replace');
 define('LABEL_Preview','preview');
 #v.2.2
@@ -487,17 +490,25 @@ define('LABEL_withSelected','with selected terms:');
 define('LABEL_rejectTerms','reject terms');
 define('LABEL_doMetaTerm','turn to meta-terms');
 define('LABEL_associateFreeTerms','associate as UF,NTE or RT');
-define('MSG_associateFreeTerms','en el siguiente paso podrá seleccionar el tipo de relación.');
+define('MSG_associateFreeTerms','in the next step you can select the type of relationship.');
 define('MSG_termsSuccessTask','terms affected by the process');
-define('LABEL_TTTerms','top terms');
+define('LABEL_TTTerms','популярные термины');
 define('MSG__GLOSSincludeAltLabel','include alternative terms');
 define('MSG__GLOSSdocumentationJSON','You can add Glossary to any HTML content using this JSON file with <a href="https://github.com/PebbleRoad/glossarizer" target="_blank" title="Glossarizer">Glossarizer</a>');
 define('LABEL_configGlossary','export source file for glossary');
-define('MSG_includeNotes','use note type:');
-define('LABEL_SHOW_RANDOM_TERM','presentar en la página de inicio un término seleccionado al azar. Se debe seleccionar un tipo de nota.');
-define('LABEL_opt_show_rando_term','show terms with type note::');
+define('MSG_includeNotes','use type note:');
+define('LABEL_SHOW_RANDOM_TERM','Show a randomly selected term on the home page.  You must select the type of term to show.');
+define('LABEL_opt_show_rando_term','show terms with type note:');
 define('MSG_helpNoteEditor','You can link terms using double brackets. Ex: Only [[love]] will save the world');
-define('LABEL_GLOSS_NOTES','Select which note type will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_GLOSS_NOTES','Select which type note will be used to enrich (glossary) the terms who are marked with double brackets : [[glossary]]');
+define('LABEL_bulkGlossNotes','type note to gloss');
+define('MSG__autoGlossInfo','This process will create wiki links between terms from the vocabulary with the terms found in notes (Ex: Only [[love]] will save the world). Is <strong>case sensitive</strong> search and replace operation.');
+define('MSG__autoGlossDanger','This process is IRREVERSIBLE. Please create a backup before proceeding.');
+define('LABEL_replaceBinary','case sensitive');
+define('MSG_notesAffected','affected notes');
+define('MSG_cantTermsFound','terms found');
+define('MENU_glossConfig','config auto-gloss'); /* Used as menu entry. Keep it short */ 
+define('LABEL_generateAutoGlossary','auto-gloss generation');
 define('LABEL_AlphaPDF','alphabetic (PDF)');
 define('LABEL_SystPDF','systematic (PDF)');
 define('LABEL_references','references');
@@ -511,4 +522,10 @@ define('LABEL_close','close');
 define('LABEL_allTerms','all terms');
 define('LABEL_allNotes','all notes');
 define('LABEL_allRelations','all terms relations');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
+
 ?>

--- a/common/lang/zh-utf-8.inc.php
+++ b/common/lang/zh-utf-8.inc.php
@@ -1,250 +1,301 @@
-﻿<?php 
-define('LANG','zh');
-define('TR_acronimo','参');
-define('TE_acronimo','分');
-define('TG_acronimo','属');
-define('UP_acronimo','代');
-define('TR_termino','相关词');
-define('TE_termino','下位词');
-define('TG_termino','上位词');
-define('UP_termino','代');
-define('USE_termino','用');
-define('MENU_ListaSis','等级体系表');
-define('MENU_ListaAbc','字顺表');
-define('MENU_Sobre','关于');
-define('MENU_Inicio','主页');
-define('MENU_MiCuenta','我的帐号');
-define('MENU_Usuarios','用户');
-define('MENU_NuevoUsuario','新用户');
-define('MENU_DatosTesauro','关于叙词表');
-define('MENU_AgregarT','新增词条');
-define('MENU_EditT','编辑词条');
-define('MENU_BorrarT','删除词条');
-define('MENU_AgregarTG','上位词');
-define('MENU_AgregarTE','下位词');
-define('MENU_AgregarTR','相关词');
-define('MENU_AgregarUP','非正式词');
-define('MENU_MisDatos','我的帐号');
-define('MENU_Caducar','禁用');
-define('MENU_Habilitar','可用');
-define('MENU_Salir','注销');
-define('LABEL_Menu','菜单');
-define('LABEL_Opciones','选项');
-define('LABEL_Admin','管理');
-define('LABEL_Agregar','新增');
-define('LABEL_editT','编辑词条');
-define('LABEL_EditorTermino','词条编辑器');
-define('LABEL_Termino','词条');
-define('LABEL_NotaAlcance','范围注释');
-define('LABEL_EliminarTE','删除词条');
-define('LABEL_AgregarT','新词条');
-define('LABEL_AgregarTG','为%s新增上位词');
-define('LABEL_AgregarTE','新词条从属于');
-define('LABEL_AgregarUP','新代位词');
-define('LABEL_AgregarTR','新相关词');
-define('LABEL_Detalle','详情');
-define('LABEL_Autor','作者');
-define('LABEL_URI','唯一资源识别符');
-define('LABEL_Version','技术支持');
-define('LABEL_Idioma','语种');
-define('LABEL_Fecha','创建日期');
-define('LABEL_Keywords','关键词');
-define('LABEL_TipoLenguaje','词表类型');
-define('LABEL_Cobertura','简介');
-define('LABEL_Terminos','词条');
-define('LABEL_RelTerminos','词间关系');
-define('LABEL_TerminosUP','非正式词');
-define('LABEL_BuscaTermino','搜索词条');
-define('LABEL_Buscar','搜索词条');
-define('LABEL_Enviar','提交');
-define('LABEL_Cambiar','更新');
-define('LABEL_Anterior','返回');
-define('LABEL_AdminUser','用户管理');
-define('LABEL_DatosUser','用户数据');
-define('LABEL_Acciones','任务');
-define('LABEL_verEsquema','模式');
-define('LABEL_actualizar','更新');
-define('LABEL_terminosLibres','自由词');
-define('LABEL_busqueda','搜索');
-define('LABEL_borraRelacion','删除关系');
-define('MSG_ResultBusca','检索式找到如下词条');
-define('MSG_ResultLetra','字母');
-define('MSG_ResultCambios','修改成功');
-define('MSG_noUser','非注册用户');
-define('FORM_JS_check','请检查数据');
-define('FORM_JS_confirm','是否清除此关系？');
-define('FORM_JS_pass','密码');
-define('FORM_JS_confirmPass','确认密码');
-define('FORM_LABEL_termino','词条');
-define('FORM_LABEL_buscar','检索式');
-define('FORM_LABEL_buscarTermino','相关词');
-define('FORM_LABEL_nombre','名');
-define('FORM_LABEL_apellido','姓');
-define('FORM_LABEL_mail','邮箱');
-define('FORM_LABEL_pass','密码');
-define('FORM_LABEL_repass','确认密码');
-define('FORM_LABEL_orga','机构');
-define('LABEL_nombre','名');
-define('LABEL_apellido','姓');
-define('LABEL_mail','邮箱');
-define('LABEL_pass','密码');
-define('LABEL_repass','确认密码');
-define('LABEL_orga','机构');
-define('LABEL_lcConfig','词表配置');
-define('LABEL_lcDatos','词表元数据');
-define('LABEL_Titulo','名称');
-define('FORM_LABEL_Titulo','名称');
-define('FORM_LABEL_Autor','作者');
-define('FORM_LABEL_URI','唯一资源标识符');
-define('FORM_LABEL_Idioma','语种');
-define('FORM_LABEL_FechaDia','日');
-define('FORM_LABEL_FechaMes','月');
-define('FORM_LABEL_FechaAno','年');
-define('FORM_LABEL_Keywords','关键词');
-define('FORM_LABEL_TipoLenguaje','词表类型');
-define('FORM_LABEL_Cobertura','范围');
-define('FORM_LABEL_Terminos','词条');
-define('FORM_LABEL_RelTerminos','词间关系');
-define('FORM_LABEL_TerminosUP','非正式词');
-define('FORM_LABEL_Guardar','保存');
-define('LABEL_verDetalle','详见');
-define('LABEL_verTerminosLetra','从此处开始查看');
-define('LABEL_NB','书目注释');
-define('LABEL_NH','沿革注释');
-define('LABEL_NA','范围注释');
-define('LABEL_NP','内部注释');
-define('LABEL_EditorNota','注释编辑器');
-define('LABEL_EditorNotaTermino','注释');
-define('LABEL_tipoNota','注释类型');
-define('FORM_LABEL_tipoNota','注释类型');
-define('LABEL_nota','注释');
-define('FORM_LABEL_nota','注释');
-define('LABEL_EditarNota','编辑注释');
-define('LABEL_EliminarNota','删除注释');
-define('LABEL_OptimizarTablas','优化表');
-define('LABEL_TotalZthesLine','导出为Zthes');
-define('LABEL_negrita','粗体');
-define('LABEL_italica','斜体');
-define('LABEL_subrayado','下划线');
-define('LABEL_textarea','主体注释');
-define('MSGL_relacionIlegal','词间不合法关系');
-define('LABEL_fecha_modificacion','已修改');
-define('LABEL_TotalUsuarios','用户总数');
-define('LABEL_TotalTerminos','词条总数');
-define('LABEL_ordenar','排序');
-define('LABEL_auditoria','词条按时间统计');
-define('LABEL_dia','日');
-define('LABEL_mes','月');
-define('LABEL_ano','年');
-define('LABEL_terminosRepetidos','重复词条');
-define('MSG_noTerminosLibres','无自由词');
-define('MSG_noTerminosRepetidos','无重复词');
-define('LABEL_TotalSkosLine','导出为SKOS-Core');
-define('LABEL_SI','是');
-define('LABEL_NO','否');
-define('FORM_LABEL_jeraquico','复合等级体系');
-define('LABEL_jeraquico','复合等级体系');
-define('LABEL_terminoLibre','自由词');
-define('LABEL_URL_busqueda','搜索%s');
-define('LABEL_relacion_vocabulario','关联词表');
-define('FORM_LABEL_relacion_vocabulario','等同');
-define('FORM_LABEL_nombre_vocabulario','目标词表');
-define('LABEL_vocabulario_referencia','目标词表');
-define('LABEL_NO_vocabulario_referencia','无目标词表可形成词间关系');
-define('FORM_LABEL_tipo_equivalencia','等同类型');
-define('LABEL_vocabulario_principal','词表');
-define('LABEL_tipo_vocabulario','类型');
-define('LABEL_termino_equivalente','等同');
-define('LABEL_termino_parcial_equivalente','部分等同');
-define('LABEL_termino_no_equivalente','非等同');
-define('EQ_acronimo','EQ');
-define('EQP_acronimo','EQP');
-define('NEQ_acronimo','NEQ');
-define('LABEL_NC','编目员注释');
-define('LABEL_resultados_suplementarios','补充结果');
-define('LABEL_resultados_relacionados','相关结果');
-define('LABEL_export','导出');
-define('FORM_LABEL_format_export','选择XML模式');
-define('LABEL_fecha_creacion','已创建');
-define('NB_acronimo','BN');
-define('NH_acronimo','HN');
-define('NA_acronimo','SN');
-define('NP_acronimo','PN');
-define('NC_acronimo','CN');
-define('LABEL_Candidato','候选词');
-define('LABEL_Aceptado','已接受词');
-define('LABEL_Rechazado','已拒绝词');
-define('LABEL_Ultimos_aceptados','最新接受词');
-define('MSG_ERROR_ESTADO','不合法状态');
-define('LABEL_Candidatos','候选词');
-define('LABEL_Aceptados','已接受词');
-define('LABEL_Rechazados','已拒绝词');
-define('LABEL_User_NoHabilitado','禁用');
-define('LABEL_User_Habilitado','启用');
-define('LABEL_CandidatearTermino','候选词');
-define('LABEL_AceptarTermino','接受词');
-define('LABEL_RechazarTermino','拒绝词');
-define('LABEL_TERMINO_SUGERIDO','你是不是要找');
-define('LABEL_esSuperUsuario','管理员');
-define('LABEL_Cancelar','取消');
-define('LABEL_Guardar','保存');
-define('MENU_AgregarTEexist','从属于一个已有词条');
-define('MENU_AgregarUPexist','关联一个已有非正式词');
-define('LABEL_existAgregarUP','为%s增加一个代位词');
-define('LABEL_existAgregarTE','为%s增加一个下位词');
-define('MSG_minCharSerarch','检索式<i>%s</i>仅包含<strong>%s </strong>个字符。必须多余<strong>%s </strong>个字符。');
-define('LABEL_terminoExistente','已有词条');
-define('HELP_variosTerminos','若要一次增加多个词条，<strong>每行一个词条</strong>。');
-define('FORM','表单');
-define('ERROR','错误');
-define('LABEL_bienvenida','欢迎来到TemaTres词表服务器');
-define('PARAM_SERVER','服务器地址');
-define('PARAM_DBName','数据库名称');
-define('PARAM_DBLogin','数据库用户');
-define('PARAM_DBPass','数据库密码');
-define('PARAM_DBprefix','前缀表');
-define('MSG_ERROR_CODE','无效代码');
-define('LABEL_CODE','代码');
-define('LABEL_Ver','显示');
-define('LABEL_OpcionesTermino','词条');
-define('LABEL_CambiarEstado','更改词条状态');
-define('LABEL_ClickEditar','点击编辑');
-define('LABEL_TopTerm','有族首词');
-define('LABEL_esFraseExacta','精确短语');
-define('LABEL_DesdeFecha','创建时或创建后');
-define('LABEL_ProfundidadTermino','定位到深层级');
-define('LABEL_esNoPreferido','非正式词');
-define('LABEL_BusquedaAvanzada','高级搜索');
-define('LABEL_Todos','所有');
-define('LABEL_QueBuscar','搜索什么？');
-define('LABEL_import','导入');
-define('IMPORT_form_legend','从文件导入叙词表');
-define('IMPORT_form_label','文件');
-define('IMPORT_file_already_exists','txt文件已存在于该服务器');
-define('IMPORT_file_not_exists','尚未导入txt文件');
-define('IMPORT_do_it','你可以开始导入');
-define('IMPORT_working','导入任务进行中');
-define('IMPORT_finish','导入任务完成');
-define('LABEL_reIndice','重建索引');
-define('LABEL_dbMantenimiento','数据库维护');
-define('LABEL_relacion_vocabularioWebService','与远程目标词表的词条关系');
-define('LABEL_vocabulario_referenciaWS','远程目标词表（Web Services）');
-define('LABEL_TargetVocabularyWS','远程目标词表（Web Services）');
-define('LABEL_tvocab_label','参照标识');
-define('LABEL_tvocab_tag','参照标签');
-define('LABEL_tvocab_uri_service','Web Services参照URL');
-define('LABEL_targetTermsforUpdate','待更新词条');
-define('LABEL_ShowTargetTermsforUpdate','检查词条更新');
-define('LABEL_enable','启用');
-define('LABEL_disable','禁用');
-define('LABEL_notFound','词条未找到');
-define('LABEL_termUpdated','词条已更新');
-define('LABEL_ShowTargetTermforUpdate','更新');
-define('LABEL_relbetweenVocabularies','词表间关系');
-define('LABEL_update1_1x1_2','更新（1.1 -> 1.3）');
-define('LABEL_update1x1_2','更新（1.0x -> 1.3）');
-define('LABEL_TargetTerm','术语映射');
-define('LABEL_TargetTerms','词条（术语映射）');
+<?php
+#   TemaTres: open source thesaurus management #       #
+#                                                                        #
+#   Copyright (C) 2004-2018 Diego Ferreyra <tematres@r020.com.ar>
+#   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
+#   Translation: Community collaborative translation https://crowdin.com/project/tematres
+#
+###############################################################################################################
+#
+define("LANG","zh");
+define("TR_acronimo","参"); /* Related Term */
+define("TE_acronimo","分"); /* Narrower term > Specific term */
+define("TG_acronimo","属"); /* Broader term > Generic term */
+define("UP_acronimo","代"); /* Used for > instead */
+define("TR_termino","相关词");
+define("TE_termino","下位词");
+define("TG_termino","上位词");
+define("UP_termino","代"); /* A term with this symbol is followed by non preferred terms (non descriptors) */
+/* v 9.5 */
+define("USE_termino","用"); /* A term with this symbol is followed by a preferred term (descriptor) */
+define("MENU_ListaSis","等级体系表");
+define("MENU_ListaAbc","字顺表");
+define("MENU_Sobre","关于");
+define("MENU_Inicio","主页");
+define("MENU_MiCuenta","我的帐号");
+define("MENU_Usuarios","用户");
+define("MENU_NuevoUsuario","新用户");
+define("MENU_DatosTesauro","关于叙词表");
+define("MENU_AgregarT","新增词条");
+define("MENU_EditT","编辑词条");
+define("MENU_BorrarT","删除词条");
+define("MENU_AgregarTG","上位词");
+define("MENU_AgregarTE","下位词");
+define("MENU_AgregarTR","相关词");
+define("MENU_AgregarUP","非正式词");  /* Non-descriptor */
+define("MENU_MisDatos","我的帐号");
+define("MENU_Caducar","禁用");
+define("MENU_Habilitar","可用");
+define("MENU_Salir","注销");
+define("LABEL_Menu","菜单");
+define("LABEL_Opciones","选项");
+define("LABEL_Admin","管理");
+define("LABEL_Agregar","新增");
+define("LABEL_editT","编辑词条");
+define("LABEL_EditorTermino","词条编辑器");
+define("LABEL_Termino","词条");
+define("LABEL_NotaAlcance","范围注释");
+define("LABEL_EliminarTE","删除词条");
+define("LABEL_AgregarT","新词条");
+define("LABEL_AgregarTG","为%s新增上位词");
+define("LABEL_AgregarTE","新词条从属于");
+define("LABEL_AgregarUP","新代位词");
+define("LABEL_AgregarTR","新相关词");
+define("LABEL_Detalle","详情");
+define("LABEL_Autor","作者");
+define("LABEL_URI","唯一资源识别符");
+define("LABEL_Version","技术支持");
+define("LABEL_Idioma","语种");
+define("LABEL_Fecha","创建日期");
+define("LABEL_Keywords","关键词");
+define("LABEL_TipoLenguaje","词表类型");
+define("LABEL_Cobertura","简介");
+define("LABEL_Terminos","词条");
+define("LABEL_RelTerminos","词间关系");
+define("LABEL_TerminosUP","非正式词");
+define("LABEL_BuscaTermino","搜索词条");
+define("LABEL_Buscar","搜索词条");
+define("LABEL_Enviar","提交");
+define("LABEL_Cambiar","更新");
+define("LABEL_Anterior","返回");
+define("LABEL_AdminUser","用户管理");
+define("LABEL_DatosUser","用户数据");
+define("LABEL_Acciones","任务");
+define("LABEL_verEsquema","模式");
+define("LABEL_actualizar","更新");
+define("LABEL_terminosLibres","自由词"); /* 'Free term' usually refers to a term from the natural language, and thus not controlled. This is not exactly what 'termino libre' means in TemaTres. Note: 'orphan' is not good either as it means 'not preferred' */
+define("LABEL_busqueda","搜索");
+define("LABEL_borraRelacion","删除关系");
+define("MSG_ResultBusca","检索式找到如下词条");
+define("MSG_ResultLetra","字母");
+define("MSG_ResultCambios","修改成功");
+define("MSG_noUser","非注册用户");
+define("FORM_JS_check","请检查数据");
+define("FORM_JS_confirm","是否清除此关系？");
+define("FORM_JS_pass","密码");
+define("FORM_JS_confirmPass","确认密码");
+define("FORM_LABEL_termino","词条");
+define("FORM_LABEL_buscar","检索式");
+define("FORM_LABEL_buscarTermino","相关词");
+define("FORM_LABEL_nombre","名");
+define("FORM_LABEL_apellido","姓");
+define("FORM_LABEL_mail","邮箱");
+define("FORM_LABEL_pass","密码");
+define("FORM_LABEL_repass","确认密码");
+define("FORM_LABEL_orga","机构");
+define("LABEL_nombre","名");
+define("LABEL_apellido","姓");
+define("LABEL_mail","邮箱");
+define("LABEL_pass","密码");
+define("LABEL_repass","确认密码");
+define("LABEL_orga","机构");
+define("LABEL_lcConfig","词表配置");
+define("LABEL_lcDatos","词表元数据");
+define("LABEL_Titulo","名称");
+define("FORM_LABEL_Titulo","名称");
+define("FORM_LABEL_Autor","作者");
+define("FORM_LABEL_URI","唯一资源标识符");
+define("FORM_LABEL_Idioma","语种");
+define("FORM_LABEL_FechaDia","日");
+define("FORM_LABEL_FechaMes","月");
+define("FORM_LABEL_FechaAno","年");
+define("FORM_LABEL_Keywords","关键词");
+define("FORM_LABEL_TipoLenguaje","词表类型");
+define("FORM_LABEL_Cobertura","范围");
+define("FORM_LABEL_Terminos","词条");
+define("FORM_LABEL_RelTerminos","词间关系");
+define("FORM_LABEL_TerminosUP","非正式词");
+define("FORM_LABEL_Guardar","保存");
+define("LABEL_verDetalle","详见");
+define("LABEL_verTerminosLetra","从此处开始查看");
+define("LABEL_NB","书目注释");
+define("LABEL_NH","沿革注释");
+define("LABEL_NA","范围注释");   /* version 0.9.1 */
+define("LABEL_NP","内部注释"); /* version 0.9.1 */
+define("LABEL_EditorNota","注释编辑器");
+define("LABEL_EditorNotaTermino","注释");
+define("LABEL_tipoNota","注释类型");
+define("FORM_LABEL_tipoNota","注释类型");
+define("LABEL_nota","注释");
+define("FORM_LABEL_nota","注释");
+define("LABEL_EditarNota","编辑注释");
+define("LABEL_EliminarNota","删除注释");
+define("LABEL_OptimizarTablas","优化表");
+define("LABEL_TotalZthesLine","导出为Zthes");
+/* v 9.2 */
+define("LABEL_negrita","粗体");
+define("LABEL_italica","斜体");
+define("LABEL_subrayado","下划线");
+define("LABEL_textarea","主体注释");
+define("MSGL_relacionIlegal","词间不合法关系");
+/* v 9.3 */
+define("LABEL_fecha_modificacion","已修改");
+define("LABEL_TotalUsuarios","用户总数");
+define("LABEL_TotalTerminos","词条总数");
+define("LABEL_ordenar","排序");
+define("LABEL_auditoria","词条按时间统计");
+define("LABEL_dia","日");
+define("LABEL_mes","月");
+define("LABEL_ano","年");
+define("LABEL_terminosRepetidos","重复词条");
+define("MSG_noTerminosLibres","无自由词");
+define("MSG_noTerminosRepetidos","无重复词");
+define("LABEL_TotalSkosLine","导出为SKOS-Core");
+$MONTHS=array("01"=>"一月",
+              "02"=>"二月",
+              "03"=>"三月",
+              "04"=>"四月",
+              "05"=>"五月",
+              "06"=>"六月",
+              "07"=>"七月",
+              "08"=>"八月",
+              "09"=>"九月",
+              "10"=>"十月",
+              "11"=>"十一月",
+              "12"=>"十二月"
+              );
+/* v 9.4 */
+define("LABEL_SI","是");
+define("LABEL_NO","否");
+define("FORM_LABEL_jeraquico","复合等级体系");
+define("LABEL_jeraquico","复合等级体系"); /* Polyhierarchical relationship */
+define("LABEL_terminoLibre","自由词");
+/* v 9.5 */
+define("LABEL_URL_busqueda","搜索%s");
+/* v 9.6 */
+define("LABEL_relacion_vocabulario","关联词表");
+define("FORM_LABEL_relacion_vocabulario","等同");
+define("FORM_LABEL_nombre_vocabulario","目标词表");
+define("LABEL_vocabulario_referencia","目标词表");
+define("LABEL_NO_vocabulario_referencia","无目标词表可形成词间关系");
+define("FORM_LABEL_tipo_equivalencia","等同类型");
+define("LABEL_vocabulario_principal","词表");
+define("LABEL_tipo_vocabulario","类型");
+define("LABEL_termino_equivalente","等同");
+define("LABEL_termino_parcial_equivalente","部分等同");
+define("LABEL_termino_no_equivalente","非等同");
+define("EQ_acronimo","EQ"); /* Exact equivalence > inter-language synonymy */
+define("EQP_acronimo","EQP"); /* Partial equivalence > inter-language quasi-synonymy with a difference in specificity*/
+define("NEQ_acronimo","NEQ"); /*  Non-equivalence */
+define("LABEL_NC","编目员注释");
+define("LABEL_resultados_suplementarios","补充结果");
+define("LABEL_resultados_relacionados","相关结果");
+/* v 9.7 */
+define("LABEL_export","导出");
+define("FORM_LABEL_format_export","选择XML模式");
+/* v 1.0 */
+define("LABEL_fecha_creacion","已创建");
+define("NB_acronimo","BN"); /* Bibliographic note */
+define("NH_acronimo","HN"); /* Historical note */
+define("NA_acronimo","SN"); /* Scope or Explanatory note */
+define("NP_acronimo","PN"); /* Private note */
+define("NC_acronimo","CN"); /* Cataloger's note */
+define("LABEL_Candidato","候选词");
+define("LABEL_Aceptado","已接受词");
+define("LABEL_Rechazado","已拒绝词");
+define("LABEL_Ultimos_aceptados","最新接受词");
+define("MSG_ERROR_ESTADO","不合法状态");
+define("LABEL_Candidatos","候选词");
+define("LABEL_Aceptados","已接受词");
+define("LABEL_Rechazados","已拒绝词");
+define("LABEL_User_NoHabilitado","禁用");
+define("LABEL_User_Habilitado","启用");
+
+define("LABEL_CandidatearTermino","候选词");
+define("LABEL_AceptarTermino","接受词");
+define("LABEL_RechazarTermino","拒绝词");
+/* v 1.01 */
+define("LABEL_TERMINO_SUGERIDO","你是不是要找");
+/* v 1.02 */
+define("LABEL_esSuperUsuario","管理员");
+define("LABEL_Cancelar","取消");
+define("LABEL_Guardar","保存");
+/* v 1.033 */
+define("MENU_AgregarTEexist","从属于一个已有词条");
+define("MENU_AgregarUPexist","关联一个已有非正式词");
+define("LABEL_existAgregarUP","为%s增加一个代位词");
+define("LABEL_existAgregarTE","为%s增加一个下位词");
+define("MSG_minCharSerarch","检索式<i>%s</i>仅包含<strong>%s </strong>个字符。必须多余<strong>%s </strong>个字符。");
+/* v 1.04 */
+define("LABEL_terminoExistente","已有词条");
+define("HELP_variosTerminos","若要一次增加多个词条，<strong>每行一个词条</strong>。");
+/* Install messages */
+define("FORM","表单") ;
+define("ERROR","错误") ;
+define("LABEL_bienvenida","欢迎来到TemaTres词表服务器") ;
+// COMMON SQL
+define("PARAM_SERVER","服务器地址") ;
+define("PARAM_DBName","数据库名称") ;
+define("PARAM_DBLogin","数据库用户") ;
+define("PARAM_DBPass","数据库密码") ;
+define("PARAM_DBprefix","前缀表") ;
+$install_message[101] = 'TemaTres Setup' ;
+$install_message[201] = 'Can not find the file configuration for the database connection (%s).';
+$install_message[202] = 'File configuration for the database connection found.';
+$install_message[203] = 'Unable to connect to database server <em>%s</em> with the user <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[204] = 'Connection to Server <em>%s</em> successful ';
+$install_message[205] = 'Unable to connect to database <em>%s</em> in server <em>%s</em>. Please check your file configuration for the database connection (%s).';
+$install_message[206] = 'Connection to database <em>%s</em> in server <em>%s</em> successful.' ;
+$install_message[301] = 'Whoops... There is already a TemaTres instance for the configuration. Please check your file configuration for the database connection (%s) or <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+$install_message[305] = 'Checking Security password.' ;
+$install_message[306] = 'Setup is completed, <a href="index.php">Enjoy your Vocabulary Server</a>' ;
+/* end Install messages */
+/* v 1.1 */
+define('MSG_ERROR_CODE',"无效代码");
+define('LABEL_CODE',"代码");
+define('LABEL_Ver',"显示");
+define('LABEL_OpcionesTermino',"词条");
+define('LABEL_CambiarEstado',"更改词条状态");
+define('LABEL_ClickEditar',"点击编辑");
+define('LABEL_TopTerm',"有族首词");
+define('LABEL_esFraseExacta',"精确短语");
+define('LABEL_DesdeFecha',"创建时或创建后");
+define('LABEL_ProfundidadTermino',"定位到深层级");
+define('LABEL_esNoPreferido',"非正式词");
+define('LABEL_BusquedaAvanzada',"高级搜索");
+define('LABEL_Todos',"所有");
+define('LABEL_QueBuscar',"搜索什么？");
+define("LABEL_import","导入") ;
+define("IMPORT_form_legend","从文件导入叙词表") ;
+define("IMPORT_form_label","文件") ;
+define("IMPORT_file_already_exists","txt文件已存在于该服务器") ;
+define("IMPORT_file_not_exists","尚未导入txt文件") ;
+define("IMPORT_do_it","你可以开始导入") ;
+define("IMPORT_working","导入任务进行中") ;
+define("IMPORT_finish","导入任务完成") ;
+define("LABEL_reIndice","重建索引") ;
+define("LABEL_dbMantenimiento","数据库维护");  /* Used as menu entry. Keep it short */ 
+/*
+v 1.2
+*/
+define('LABEL_relacion_vocabularioWebService',"与远程目标词表的词条关系");
+define('LABEL_vocabulario_referenciaWS',"远程目标词表（Web Services）");
+define('LABEL_TargetVocabularyWS',"远程目标词表（Web Services）");
+define('LABEL_tvocab_label',"参照标识");
+define('LABEL_tvocab_tag',"参照标签");
+define('LABEL_tvocab_uri_service',"Web Services参照URL");
+define('LABEL_targetTermsforUpdate',"待更新词条");
+define('LABEL_ShowTargetTermsforUpdate',"检查词条更新");
+define('LABEL_enable',"启用");
+define('LABEL_disable',"禁用");
+define('LABEL_notFound',"词条未找到");
+define('LABEL_termUpdated',"词条已更新");
+define('LABEL_ShowTargetTermforUpdate',"更新");
+define('LABEL_relbetweenVocabularies',"词表间关系");
+define('LABEL_update1_1x1_2',"更新（1.1 -> 1.3）");
+define('LABEL_update1x1_2',"更新（1.0x -> 1.3）");
+define('LABEL_TargetTerm',"术语映射");
+define('LABEL_TargetTerms',"词条（术语映射）");
 define('LABEL_seleccionar','选择XML模式');
 define('LABEL_poliBT','多于1个上位词');
 define('LABEL_FORM_simpleReport','报告');
@@ -258,10 +309,16 @@ define('LABEL_end','结束于');
 define('LABEL_equalThisWord','精确匹配');
 define('LABEL_haveWords','包含单词');
 define('LABEL_encode','编码');
+/*
+v1.21
+*/
 define('LABEL_import_skos','SKOS-Core导入');
 define('IMPORT_skos_file_already_exists','SKOS-Core来源在服务器上');
 define('IMPORT_skos_form_legend','导入SKOS-Core');
 define('IMPORT_skos_form_label','SKOS-Core文件');
+/*
+v1.4
+*/
 define('LABEL_termsxNTterms','下位词 x 词条');
 define('LABEL_termsNoBT','无等级关系词');
 define('MSG_noTermsNoBT','无等级关系的词条不存在');
@@ -275,28 +332,31 @@ define('LABEL_CFG_NUM_SHOW_TERMSxSTATUS','按状态视图显示词条数');
 define('LABEL_CFG_MIN_SEARCH_SIZE','搜索提交的最小字符数');
 define('LABEL__SHOW_TREE','在主页发布层级视图');
 define('LABEL__PUBLISH_SKOS','在Web Services中启用SKOS-Core格式。这样做会公开整个词表。');
-define('LABEL_update1_3x1_4','更新（1.3x -> 1.4）');
-define('FORM_LABEL_format_import','选择格式');
-define('LABEL_importTab','表格文本');
-define('LABEL_importTag','标记文本');
-define('LABEL_importSkos','SKOS-Core');
-define('LABEL_configTypeNotes','配置注释类型');
-define('LABEL_notes','注释');
-define('LABEL_saved','保存');
-define('FORM_JS_confirmDeleteTypeNote','是否清除此注释类型？');
-define('LABEL_relationEditor','关系编辑器');
-define('LABEL_relationDelete','删除关系子类型');
-define('LABEL_relationSubType','关系类型');
-define('LABEL_relationSubTypeCode','关系子类型别名');
-define('LABEL_relationSubTypeLabel','关系子类型标记');
-define('LABEL_optative','可选');
+define('LABEL_update1_3x1_4',"更新（1.3x -> 1.4）");
+define("FORM_LABEL_format_import","选择格式");
+define("LABEL_importTab","表格文本");
+define("LABEL_importTag","标记文本");
+define("LABEL_importSkos","SKOS-Core");
+define("LABEL_configTypeNotes","配置注释类型");
+define("LABEL_notes","注释");
+define("LABEL_saved","保存");
+define("FORM_JS_confirmDeleteTypeNote","是否清除此注释类型？");
+/*
+v1.5
+*/
+define("LABEL_relationEditor","关系编辑器");
+define("LABEL_relationDelete","删除关系子类型");
+define('LABEL_relationSubType',"关系类型");
+define('LABEL_relationSubTypeCode',"关系子类型别名");
+define('LABEL_relationSubTypeLabel',"关系子类型标记");
+define('LABEL_optative',"可选");
 define('FORM_JS_confirmDeleteTypeRelation','删除此关系子类型');
-define('LABEL_URItypeEditor','链接类型编辑器');
-define('LABEL_URIEditor','管理与此词条相关的链接');
-define('LABEL_URItypeDelete','删除链接类型');
-define('LABEL_URItype','链接类型');
-define('LABEL_URItypeCode','链接类型别名');
-define('LABEL_URItypeLabel','链接类型标记');
+define("LABEL_URItypeEditor","链接类型编辑器");
+define("LABEL_URIEditor","管理与此词条相关的链接");
+define("LABEL_URItypeDelete","删除链接类型");
+define('LABEL_URItype',"链接类型");
+define('LABEL_URItypeCode',"链接类型别名");
+define('LABEL_URItypeLabel',"链接类型标记");
 define('FORM_JS_confirmDeleteURIdefinition','是否删除此链接类型');
 define('LABEL_URI2term','网络资源');
 define('LABEL_URI2termURL','网络资源链接');
@@ -304,6 +364,9 @@ define('LABEL_update1_4x1_5','更新 (1.4 -> 1.5)');
 define('LABEL_Contributor','贡献者');
 define('LABEL_Rights','版权');
 define('LABEL_Publisher','发布者');
+/*
+v1.6
+*/
 define('LABEL_Prev','上一页');
 define('LABEL_Next','下一页');
 define('LABEL_PageNum','搜索结果数');
@@ -334,6 +397,7 @@ define('MSG_check_mail_link','检查你的邮件，找到确认链接。');
 define('MSG_check_mail','请检查你的邮箱。');
 define('MSG_no_mail','电子邮件未能发送。');
 define('LABEL_user_lost_password','忘记密码？');
+## v1.7
 define('LABEL_includeMetaTerm','包含元词条');
 define('NOTE_isMetaTerm','是元词条');
 define('NOTE_isMetaTermNote','元词条是词条的一种。它能描述其他词条，但不能用于索引。例如：引导词条、分面、类目等。');
@@ -355,18 +419,22 @@ define('MSG__need2setup_endpoint','SPARQL Endpoint需要更新，请联系管理
 define('LABEL_SPARQLEndpoint','SPARQL Endpoint');
 define('LABEL_AgregarRTexist','选择要链接的词条，作为相关词');
 define('MENU_selectExistTerm','选择已有词条');
-define('TT_terminos','族首词');
+define("TT_terminos","族首词");
+## v1.72
 define('MSG__warningDeleteTerm','此词条<i>%s</i> 将被 <strong>删除</strong>');
 define('MSG__warningDeleteTerm2row','将删除<strong>所有</strong>词条的注释和关系，此操作不可撤销！');
+## v1.8
 define('LABEL__getForRecomendation','词间映射');
 define('LABEL__getForRecomendationFor','词间映射');
 define('FORM_LABEL__contactMail','得到建议给');
 define('LABEL_addMapLink','增加词表映射');
 define('LABEL_addExactLink','增加参照链接');
 define('LABEL_addSourceNote','增加来源注释');
+## v1.82
 define('LABEL_FORM_mappedTermReport','词表关系');
 define('LABEL_eliminar','删除');
-define('MSG_termsNoDeleted','此词条已被删除');
+##v.2
+define('MSG_termsNoDeleted','the terms were not deleted');
 define('MSG_termsDeleted','删除词条');
 define('LABEL_selectAll','选择全部');
 define('LABEL_metadatos','元数据');
@@ -379,10 +447,10 @@ define('LABEL_helpSearchFreeTerms','仅自由词');
 define('LABEL_broatherTerms','上位词');
 define('LABEL_type2filter','根据类型筛选词条');
 define('LABEL_defaultEQmap','输入“eq”来定义等同关系');
-define('MSG_repass_error','密码不正确');
-define('MSG_lengh_error','请输入至少%d个字符');
-define('MSG_errorPostData','检测到错误，请检查此字段的数据。');
-define('LABEL_preferedTerms','正式词');
+define("MSG_repass_error","密码不正确");
+define("MSG_lengh_error","请输入至少%d个字符");
+define("MSG_errorPostData","检测到错误，请检查此字段的数据。");
+define('LABEL_preferedTerms','正式词');   /* Descriptor */
 define('LABEL_FORM_NULLnotesTermReport','无注释的词条');
 define('MSG_FORM_NULLnotesTermReport','无注释类型的词条');
 define('LABELnoNotes','无注释的词条');
@@ -394,6 +462,7 @@ define('LABEL_showNewsTerm','显示最近更新');
 define('LABEL_newsTerm','最近更新');
 define('MSG_contactAdmin','联系管理员');
 define('LABEL_addTargetVocabulary','增加外部词表（术语Web Serivces）');
+#v.2.1
 define('LABEL_duplicatedTerm','重复词');
 define('LABEL_duplicatedTerms','重复词');
 define('MSG_duplicatedTerms','此词表的配置不允许出现重复词条');
@@ -415,6 +484,7 @@ define('LABEL_ALLOW_DUPLICATED','启用重复词条？');
 define('LABEL_CFG_PUBLISH','是否发布词表以供任何人查看？');
 define('LABEL_Replace','替换');
 define('LABEL_Preview','预览');
+#v.2.2
 define('LABEL_selectRelation','选择类型关系');
 define('LABEL_withSelected','根据所选词条');
 define('LABEL_rejectTerms','拒绝词条');
@@ -437,12 +507,13 @@ define('MSG__autoGlossDanger','该过程不可撤销，请在操作之前创建�
 define('LABEL_replaceBinary','大小写敏感');
 define('MSG_notesAffected','受影响的注释');
 define('MSG_cantTermsFound','找到的词条');
-define('MENU_glossConfig','配置自动注解');
+define('MENU_glossConfig','配置自动注解'); /* Used as menu entry. Keep it short */ 
 define('LABEL_generateAutoGlossary','自动注解生成');
 define('LABEL_AlphaPDF','字顺方式（PDF）');
 define('LABEL_SystPDF','系统方式（PDF）');
 define('LABEL_references','参照');
 define('LABEL_printData','打印日期');
+##v.3
 define('MENU_bulkTranslate','多语种编辑器');
 define('LABEL_bulkTranslate','映射与多语种编辑器');
 define('LABEL_termsEQ','包含映射');
@@ -451,18 +522,10 @@ define('LABEL_close','关闭');
 define('LABEL_allTerms','所有词条');
 define('LABEL_allNotes','所有注释');
 define('LABEL_allRelations','所有词条关系');
+// Translation versioning
+define('LABEL_i18n_MasterDate','2018-09-12'); /* Master language file creation date (YYYY-MM-DD). Do not translate */
+define('LABEL_i18n_MasterVersion','3.0.03'); /* Master language file version. Do not translate */
+define('LABEL_i18n_TranslationVersion','01'); /* Translation language file version. Will be used after the master version number. Can be changed to track minor changes to your translation file */
+define('LABEL_i18n_TranslationAuthor','Community translation for TemaTres.'); /* Do not include emails or personal details */
 
-$MONTHS=array("01"=>"一月",
-              "02"=>"二月",
-              "03"=>"三月",
-              "04"=>"四月",
-              "05"=>"五月",
-              "06"=>"六月",
-              "07"=>"七月",
-              "08"=>"八月",
-              "09"=>"九月",
-              "10"=>"十月",
-              "11"=>"十一月",
-              "12"=>"十二月"
-              );
 ?>


### PR DESCRIPTION
All translations cleaned up and updated.
Note: language files have now the same string ordering than the master file (english).

Translations was uploaded from github into Crowdin. Strings was ordered accordingly the master file.
Strings without translation get english values automatic filled from the master language (when working in Crowdin you will see they are empty and waiting for your translation). So its easy to know what to translate.


Note: Files downloaded from Crowdin. All improvements by translators must be done using Crowdin
https://crowdin.com/project/tematres

Actual stats (please join in to translate/proofread your work):
![tematres-translation2](https://user-images.githubusercontent.com/3055443/45561240-2bacde80-b83f-11e8-9228-85f489a7eb15.png)
