### PR TITLE
Including target="_blank" to software about link

### DIFF
--- a/vocab/sobre.php
+++ b/vocab/sobre.php
@@ -42,9 +42,9 @@ $metadata=do_meta_tag();
 <div id="footer" class="footer">
       <div class="container">
         <div class="row">
-          <a href="http://www.vocabularyserver.com/" title="TemaTres: vocabulary server">
-            <img src="<?php echo T3_WEBPATH;?>/images/tematres-logo.gif"  width="42" alt="TemaTres"/></a>
-            <a href="http://www.vocabularyserver.com/" title="TemaTres: vocabulary server">TemaTres</a>
+          <a href="http://www.vocabularyserver.com/" title="TemaTres: vocabulary server" target="_blank">
+            <img src="<?php echo T3_WEBPATH;?>/images/tematres-logo.gif" width="42" alt="TemaTres"/></a>
+            <a href="http://www.vocabularyserver.com/" title="TemaTres: vocabulary server" target="_blank">TemaTres</a>
 <p class="navbar-text pull-left">
         <?php
         //are enable SPARQL


### PR DESCRIPTION
In order to not loose users from the vocab window when but opening the external URL in a new page.

Note: Maybe should also be changed the tematres-logo.gif for the 
There should also be declared the height property for the image as in
`width="42" height="43"`

Suggestion: 
Would also love an option to use an additional custom logo and link (without having to code it, same has its used for the header file in config.tematres.php!) so the about page could act as a "Click here for more information on this vocab"