### PR TITLE
Turn the login form into a modal

### DIFF
--- a/common/include/fun.html.php
+++ b/common/include/fun.html.php
@@ -2098,7 +2098,7 @@ $rows.='<nav class="navbar navbar-inverse" role="navigation">
   			$rows.=HTMLmainMenu();
         }else{//no hay session de usuario
 
- 			$rows.='<li><a href="login.php" title="'.MENU_MiCuenta.'">'.MENU_MiCuenta.'</a></li>';
+ 			$rows.='<li><a href="login-modal.php" title="'.MENU_MiCuenta.'" data-toggle="modal" data-target="#remoteModal">'.MENU_MiCuenta.'</a></li>';
         };
 
   $focus=($_GET["taskSearch"]=='1') ? 'autofocus':'';
@@ -2116,7 +2116,12 @@ $rows.='<nav class="navbar navbar-inverse" role="navigation">
     </div>
 
   </div>
-</nav>';
+</nav>
+<div class="modal fade" id="remoteModal" tabindex="-1" role="dialog" aria-labelledby="remoteModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content"></div>
+  </div>
+</div>';
 
 return $rows;
 }

--- a/common/include/session.php
+++ b/common/include/session.php
@@ -97,7 +97,7 @@ $chk_user=ARRAYcheckLogin($_POST["id_correo_electronico"]);
 		$_SESSION[$_SESSION["CFGURL"]]["ssuser_nombre"]=$chk_user["name"];
 		//redirigir
 		$_SESSION[$_SESSION["CFGURL"]]["user_data"]=ARRAYUserData($chk_user["user_id"]);
-		header("Location:index.php");
+		header("Location: " . $_SERVER['HTTP_REFERER']);
 	}
  }
 }

--- a/vocab/login-modal.php
+++ b/vocab/login-modal.php
@@ -1,0 +1,37 @@
+<?php
+#   TemaTres : aplicación para la gestión de lenguajes documentales #       #
+#                                                                        #
+#   Copyright (C) 2004-2015 Diego Ferreyra tematres@r020.com.ar
+#   Distribuido bajo Licencia GNU Public License, versión 2 (de junio de 1.991) Free Software Foundation
+#
+###############################################################################################################
+#
+include("config.tematres.php"); ?>
+<!DOCTYPE html>
+<html lang="<?php echo LANG;?>">
+  <body>
+    <div class="modal-header">TemaTres Login Page</div>
+    <div class="modal-body">
+<?php
+ if($_SESSION[$_SESSION["CFGURL"]]["ssuser_id"]){
+            require_once(T3_ABSPATH . 'common/include/inc.misTerminos.php');
+    }else{
+
+	if($_POST["task"]=='user_recovery')	{
+		$task_result=recovery($_POST["id_correo_electronico_recovery"]);
+	}
+
+
+	if ((@$_GET["task"])&&($_GET["task"]=='recovery'))	{
+		echo HTMLformRecoveryPassword();
+	}	else	{
+
+		if(($_POST["task"]=='login') && (!$_SESSION[$_SESSION["CFGURL"]]["ssuser_id"]))		{
+			$task_result=array("msg"=>t3_messages('no_user'));
+		}
+		echo HTMLformLogin($task_result);
+	};
+ }// if session ?></div>
+    <div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal">Close</button></div>
+  </body>
+</html>


### PR DESCRIPTION
If you visit a term's detail page (or even perform a search) and then try to log in to your TemaTres account, upon a successful login you get redirected to `vocab/index.php`, thus "losing" the page you were visiting prior to logging in.

The changes suggested in this pull request turn the login form into a modal, the main benefit of which is that TemaTres will now "remember" the page you came from before logging in.