### PR TITLE
Fix typo in strlen call

### DIFF
--- a/common/include/fun.html.php
+++ b/common/include/fun.html.php
@@ -1949,7 +1949,7 @@ function HTMLduplicatedTermsAlert($arrayDuplicatedTerms)
 function HTMLlinkTerm($arrayTerm, $arg = array())
 {
 
-    $class=(strlen(array2value("style", $arg)>0)) ? $arg["style"] : '' ;
+    $class=(strlen(array2value("style", $arg))>0) ? $arg["style"] : '' ;
 
     $class.=(array2value("isMetaTerm",$arrayTerm)==1) ? ' metaTerm' : '' ;
 


### PR DESCRIPTION
This trivial change ought to fix #84 (regardless of the PHP version used).